### PR TITLE
feat: 修复ck较多时报Argument list too long而无法正常使用的问题

### DIFF
--- a/jdCookie.js
+++ b/jdCookie.js
@@ -1,10 +1,17 @@
 /*
+================================================================================
+魔改自 https://github.com/shufflewzc/faker2/blob/main/jdCookie.js
+修改内容：与task_before.sh配合，由task_before.sh设置要设置要做互助的活动的 ShareCodeConfigName 和 ShareCodeEnvName 环境变量，
+        然后在这里实际解析/ql/log/.ShareCode中该活动对应的配置信息（由code.sh生成和维护），注入到nodejs的环境变量中
+修改原因：原先的task_before.sh直接将互助信息注入到shell的env中，在ck超过45以上时，互助码环境变量过大会导致调用一些系统命令
+        （如date/cat）时报 Argument list too long，而在node中修改环境变量不会受这个限制，也不会影响外部shell环境，确保脚本可以正常运行
+魔改作者：风之凌殇
+================================================================================
+
 此文件为Node.js专用。其他用户请忽略
  */
 //此处填写京东账号cookie。
 let CookieJDs = [
-  '',//账号一ck,例:pt_key=XXX;pt_pin=XXX;
-  '',//账号二ck,例:pt_key=XXX;pt_pin=XXX;如有更多,依次类推
 ]
 // 判断环境变量里面是否有京东ck
 if (process.env.JD_COOKIE) {
@@ -25,10 +32,70 @@ if (JSON.stringify(process.env).indexOf('GITHUB')>-1) {
 }
 CookieJDs = [...new Set(CookieJDs.filter(item => !!item))]
 console.log(`\n====================共${CookieJDs.length}个京东账号Cookie=========\n`);
-console.log(`==================脚本执行- 北京时间(UTC+8)：${new Date(new Date().getTime() + new Date().getTimezoneOffset()*60*1000 + 8*60*60*1000).toLocaleString()}=====================\n`)
+console.log(`==================脚本执行- 北京时间(UTC+8)：${new Date(new Date().getTime() + new Date().getTimezoneOffset()*60*1000 + 8*60*60*1000).toLocaleString('zh', {hour12: false}).replace(' 24:',' 00:')}=====================\n`)
 if (process.env.JD_DEBUG && process.env.JD_DEBUG === 'false') console.log = () => {};
 for (let i = 0; i < CookieJDs.length; i++) {
   if (!CookieJDs[i].match(/pt_pin=(.+?);/) || !CookieJDs[i].match(/pt_key=(.+?);/)) console.log(`\n提示:京东cookie 【${CookieJDs[i]}】填写不规范,可能会影响部分脚本正常使用。正确格式为: pt_key=xxx;pt_pin=xxx;（分号;不可少）\n`);
   const index = (i + 1 === 1) ? '' : (i + 1);
   exports['CookieJD' + index] = CookieJDs[i].trim();
+}
+
+// 以下为注入互助码环境变量（仅nodejs内起效）的代码
+function SetShareCodesEnv(nameConfig = "", envName = "") {
+    let rawCodeConfig = {}
+
+    // 读取互助码
+    shareCodeLogPath = `${process.env.QL_DIR}/log/.ShareCode/${nameConfig}.log`
+    let fs = require('fs')
+    if (fs.existsSync(shareCodeLogPath)) {
+        // 因为faker2目前没有自带ini，改用已有的dotenv来解析
+        // // 利用ini模块读取原始互助码和互助组信息
+        // let ini = require('ini')
+        // rawCodeConfig = ini.parse(fs.readFileSync(shareCodeLogPath, 'utf-8'))
+
+        // 使用env模块
+        require('dotenv').config({path: shareCodeLogPath})
+        rawCodeConfig = process.env
+    }
+
+    // 解析每个用户的互助码
+    codes = {}
+    Object.keys(rawCodeConfig).forEach(function (key) {
+        if (key.startsWith(`My${nameConfig}`)) {
+            codes[key] = rawCodeConfig[key]
+        }
+    });
+
+    // 解析每个用户要帮助的互助码组，将用户实际的互助码填充进去
+    let helpOtherCodes = {}
+    Object.keys(rawCodeConfig).forEach(function (key) {
+        if (key.startsWith(`ForOther${nameConfig}`)) {
+            helpCode = rawCodeConfig[key]
+            for (const [codeEnv, codeVal] of Object.entries(codes)) {
+                helpCode = helpCode.replace("${" + codeEnv + "}", codeVal)
+            }
+
+            helpOtherCodes[key] = helpCode
+        }
+    });
+
+    // 按顺序用&拼凑到一起，并放入环境变量，供目标脚本使用
+    let shareCodes = []
+    let totalCodeCount = Object.keys(helpOtherCodes).length
+    for (let idx = 1; idx <= totalCodeCount; idx++) {
+        shareCodes.push(helpOtherCodes[`ForOther${nameConfig}${idx}`])
+    }
+    let shareCodesStr = shareCodes.join('&')
+    process.env[envName] = shareCodesStr
+
+    console.info(`【风之凌殇】 友情提示：为避免ck超过45以上时，互助码环境变量过大而导致调用一些系统命令（如date/cat）时报 Argument list too long，改为在nodejs中设置 ${nameConfig} 的 互助码环境变量 ${envName}，共计 ${totalCodeCount} 组互助码，总大小为 ${shareCodesStr.length}`)
+}
+
+// 若在task_before.sh 中设置了要设置互助码环境变量的活动名称和环境变量名称信息，则在nodejs中处理，供活动使用
+let nameConfig = process.env.ShareCodeConfigName
+let envName = process.env.ShareCodeEnvName
+if (nameConfig && envName) {
+    SetShareCodesEnv(nameConfig, envName)
+} else {
+    console.debug(`【风之凌殇】 友情提示：当前未设置 ShareCodeConfigName 或 ShareCodeEnvName 环境变量，将不会尝试在nodejs中生成互助码的环境变量。ps: 两个值目前分别为 ${nameConfig} ${envName}`)
 }

--- a/shareCode/code.sh
+++ b/shareCode/code.sh
@@ -1,0 +1,699 @@
+#!/usr/bin/env bash
+
+## 基于 https://t.me/update_help/41?single
+
+## Build 20211009-001
+
+## 导入通用变量与函数
+dir_shell=/ql/shell
+. $dir_shell/share.sh
+
+## 预设的仓库及默认调用仓库设置
+## 将"repo=$repo1"改成repo=$repo2"或其他，以默认调用其他仓库脚本日志
+## 也可自行搜索本脚本内的"name_js=("和"name_js_only",将"repo"改成"repo2"或其他，用以自由组合调用仓库的脚本日志
+repo1='panghu999_jd_scripts'                       #预设的 panghu999 仓库
+repo2='JDHelloWorld_jd_scripts'                    #预设的 JDHelloWorld 仓库
+repo3='he1pu_JDHelp'                               #预设的 he1pu 仓库
+repo4='shufflewzc_faker2'                          #预设的 shufflewzc 仓库
+repo5='Wenmoux_scripts_wen_chinnkarahoi'           #预设的 Wenmoux 仓库，用于读取口袋书店互助码。需提前拉取温某人的仓库或口袋书店脚本并完整运行。
+repo6='Aaron-lv_sync_jd_scripts'                   #预设的 Aaron-lv 仓库
+repo7='smiek2221_scripts'                          #预设的 smiek2221 仓库
+repo=$repo4                                        #默认调用 shufflewzc_faker2 仓库脚本日志
+
+## 调试模式开关，默认是0，表示关闭；设置为1，表示开启
+DEBUG="1"
+
+## 本脚本限制的最大线程数量
+proc_num="8"
+
+## 备份配置文件开关，默认是1，表示开启；设置为0，表示关闭。备份路径 /ql/config/bak/
+BACKUP="1"
+## 是否删除指定天数以前的备份文件开关，默认是1，表示开启；设置为0，表示关闭。删除路径 /ql/config/bak/
+CLEANBAK="1"
+## 定义删除指定天数以前的备份文件
+CLEANBAK_DAYS="2"
+
+## 定义 jcode 脚本导出的互助码模板样式（选填）
+## 不填 使用“按编号顺序互助模板”，Cookie编号在前的优先助力
+## 填 0 使用“全部一致互助模板”，所有账户要助力的码全部一致
+## 填 1 使用“均等机会互助模板”，所有账户获得助力次数一致
+## 填 2 使用“随机顺序互助模板”，本套脚本内账号间随机顺序助力，每次生成的顺序都不一致。
+HelpType=""
+
+## 定义指定活动采用指定的互助模板。
+## 设定值为 DiyHelpType="1" 表示启用功能；不填或填其他内容表示不开启功能。
+## 如果只是想要控制某个活动以执行某种互助规则，可以参考下面 case 这个命令的例子来控制
+## 活动名称参见 name_config 定义内容；具体可在本脚本中搜索 name_config=( 获悉
+DiyHelpType="0"
+diy_help_rules(){
+    case $1 in
+        Fruit)
+            tmp_helptype="0"            # 东东农场使用“全部一致互助模板”，所有账户要助力的码全部一致
+            ;;
+        DreamFactory | JdFactory)
+            tmp_helptype="1"            # 京喜工厂和东东工厂使用“均等机会互助模板”，所有账户获得助力次数一致
+            ;;
+        Jdzz | Joy)
+            tmp_helptype="2"            # 京东赚赚和疯狂的Joy使用“随机顺序互助模板”，本套脚本内账号间随机顺序助力，每次生成的顺序都不一致。
+            ;;
+        *)
+            tmp_helptype=$HelpType      # 其他活动仍按默认互助模板生产互助规则。
+            ;;
+    esac
+}
+
+## 定义屏蔽模式。被屏蔽的账号将不被助力，被屏蔽的账号仍然可以助力其他账号。
+## 设定值为 BreakHelpType="1" 表示启用屏蔽模式；不填或填其他内容表示不开启功能。
+## 自定义屏蔽账号序号或序号区间。当 BreakHelpType="1"时生效。
+## 设定值为一个或多个不相同正整数，每个正整数不大于账号总数；也可以设置正整数区间，最大正整数不大于账号总数；
+## 如：a) 设定为 BreakHelpNum="3" 表示第 3 个账号不被助力；
+##     b) 设定为 BreakHelpNum="5 7 8 10" 表示第 5 7 8 10 个账号均不被助力；
+##     c) 设定为 BreakHelpNum="6-12" 表示从第 6 至 12 个账号均不被助力；
+##     d) 设定为 BreakHelpNum="4 9-14 15~18 19_21" 表示第4个账号、第9至14账号、第15至18账号、第19至21账号均不被助力。注意序号区间连接符仅支持 - ~ _；
+## 不按示例填写可能引发报错。
+BreakHelpType="0"                  ## 屏蔽模式
+BreakHelpNum="4 9-14 15~18 19_21"  ## 屏蔽账号序号或序号区间
+
+## 定义是否自动更新配置文件中的互助码和互助规则
+## 默认为 UpdateType="1" 表示更新互助码和互助规则；UpdateType="2" 表示只更新互助码，不更新互助规则；UpdateType="3" 表示只更新互助规则，不更新互助码；留空或其他数值表示不更新。
+UpdateType="1"
+
+## 定义是否自动安装或修复缺失的依赖，默认为1，表示自动修复；留空或其他数值表示不修复。
+FixDependType="1"
+## 定义监控修复的依赖名称
+package_name="canvas png-js date-fns axios crypto-js ts-md5 tslib @types/node dotenv typescript fs require tslib jsdom"
+
+## 需组合的环境变量列表，env_name需要和var_name一一对应，如何有新活动按照格式添加(不懂勿动)
+env_name=(
+  FRUITSHARECODES
+  PETSHARECODES
+  PLANT_BEAN_SHARECODES
+  DREAM_FACTORY_SHARE_CODES
+  DDFACTORY_SHARECODES
+  JDJOY_SHARECODES
+  JDZZ_SHARECODES
+  JXNC_SHARECODES
+  BOOKSHOP_SHARECODES
+  JD_CASH_SHARECODES
+  JDSGMH_SHARECODES
+  JDCFD_SHARECODES
+  JDHEALTH_SHARECODES
+  JD818_SHARECODES
+  CITY_SHARECODES
+  MONEYTREE_SHARECODES
+)
+var_name=(
+  ForOtherFruit
+  ForOtherPet
+  ForOtherBean
+  ForOtherDreamFactory
+  ForOtherJdFactory
+  ForOtherJoy
+  ForOtherJdzz
+  ForOtherJxnc
+  ForOtherBookShop
+  ForOtherCash
+  ForOtherSgmh
+  ForOtherCfd
+  ForOtherHealth
+  ForOtherCarni
+  ForOtherCity
+  ForOtherMoneyTree
+)
+
+## name_js为脚本文件名，如果使用ql repo命令拉取，文件名含有作者名
+## 所有有互助码的活动，把脚本名称列在 name_js 中，对应 config.sh 中互助码后缀列在 name_config 中，中文名称列在 name_chinese 中。
+## name_js、name_config 和 name_chinese 中的三个名称必须一一对应。
+name_js=(
+  "$repo"_jd_fruit
+  "$repo"_jd_pet
+  "$repo"_jd_plantBean
+  "$repo"_jd_dreamFactory
+  "$repo"_jd_jdfactory
+  "$repo"_jd_crazy_joy
+  "$repo"_jd_jdzz
+  "$repo"_jd_jxnc
+  "$repo"_jd_bookshop
+  "$repo"_jd_cash
+  "$repo"_jd_sgmh
+  "$repo"_jd_cfd
+  "$repo"_jd_health
+  "$repo"_jd_carnivalcity
+  "$repo"_jd_city
+  "$repo"_jd_moneyTree_heip
+  "$repo"_jd_cfd
+)
+
+name_config=(
+  Fruit
+  Pet
+  Bean
+  DreamFactory
+  JdFactory
+  Joy
+  Jdzz
+  Jxnc
+  BookShop
+  Cash
+  Sgmh
+  Cfd
+  Health
+  Carni
+  City
+  MoneyTree
+  TokenJxnc
+)
+
+name_chinese=(
+  东东农场
+  东东萌宠
+  京东种豆得豆
+  京喜工厂
+  东东工厂
+  crazyJoy任务
+  京东赚赚
+  京喜农场
+  口袋书店
+  签到领现金
+  闪购盲盒
+  京喜财富岛
+  东东健康社区
+  京东手机狂欢城
+  城城领现金
+  摇钱树
+  京喜token
+)
+
+## 生成pt_pin清单
+gen_pt_pin_array() {
+  local envs=$(eval echo "\$JD_COOKIE")
+  local array=($(echo $envs | sed 's/&/ /g'))
+  local tmp1 tmp2 i pt_pin_temp
+  for i in "${!array[@]}"; do
+    pt_pin_temp=$(echo ${array[i]} | perl -pe "{s|.*pt_pin=([^; ]+)(?=;?).*|\1|; s|%|\\\x|g}")
+    remark_name[i]=$(cat $dir_db/env.db | grep ${array[i]} | perl -pe "{s|.*remarks\":\"([^\"]+).*|\1|g}" | tail -1)
+    [[ $pt_pin_temp == *\\x* ]] && pt_pin[i]=$(printf $pt_pin_temp) || pt_pin[i]=$pt_pin_temp
+  done
+}
+
+## 导出互助码的通用程序，$1：去掉后缀的脚本名称，$2：config.sh中的后缀，$3：活动中文名称
+export_codes_sub() {
+    local task_name=$1
+    local config_name=$2
+    local chinese_name=$3
+    local config_name_my=My$config_name
+    local config_name_for_other=ForOther$config_name
+    local tmp_helptype=$HelpType
+    local BreakHelpInterval=$(echo $BreakHelpNum | perl -pe "{s|~|-|; s|_|-|}" | sed 's/\(\d\+\)-\(\d\+\)/{\1..\2}/g')
+    local BreakHelpNumArray=($(eval echo $BreakHelpInterval))
+    local BreakHelpNumVerify=$(echo $BreakHelpNum | sed 's/ //g' | perl -pe "{s|-||; s|~||; s|_||}" | sed 's/^\d\+$//g')
+    local i j k m n t pt_pin_in_log code tmp_grep tmp_my_code tmp_for_other user_num tmp_helptype HelpTemp random_num_list
+    local envs=$(eval echo "\$JD_COOKIE")
+    local array=($(echo $envs | sed 's/&/ /g'))
+    local user_sum=${#array[*]}
+    if cd $dir_log/$task_name &>/dev/null && [[ $(ls) ]]; then
+        ## 寻找所有互助码以及对应的pt_pin
+        i=0
+        pt_pin_in_log=()
+        code=()
+        pt_pin_and_code=$(ls -r *.log | xargs awk -v var="的$chinese_name好友互助码" 'BEGIN{FS="[（ ）】]+"; OFS="&"} $3~var {print $2,$4}')
+        for line in $pt_pin_and_code; do
+            pt_pin_in_log[i]=$(echo $line | awk -F "&" '{print $1}')
+            code[i]=$(echo $line | awk -F "&" '{print $2}')
+            let i++
+        done
+
+        ## 输出My系列变量
+        if [[ ${#code[*]} -gt 0 ]]; then
+            for ((m = 0; m < ${#pt_pin[*]}; m++)); do
+                tmp_my_code=""
+                j=$((m + 1))
+                for ((n = 0; n < ${#code[*]}; n++)); do
+                    if [[ ${pt_pin[m]} == ${pt_pin_in_log[n]} ]]; then
+                        tmp_my_code=${code[n]}
+                        break
+                    fi
+                done
+                echo "$config_name_my$j='$tmp_my_code'"
+            done
+        else
+            echo "## 从日志中未找到任何互助码"
+        fi
+
+        ## 输出ForOther系列变量
+        if [[ ${#code[*]} -gt 0 ]]; then
+            [[ $DiyHelpType = "1" ]] && diy_help_rules $2
+            case $tmp_helptype in
+            0) ## 全部一致
+                HelpTemp="全部一致"
+                echo -e "\n## 采用\"$HelpTemp\"互助模板："
+                tmp_for_other=""
+                for ((m = 0; m < ${#pt_pin[*]}; m++)); do
+                    j=$((m + 1))
+                    if [[ $BreakHelpType = "1" ]]; then
+                        if [ "$BreakHelpNumVerify" = "" ]; then
+                            for ((t = 0; t < ${#BreakHelpNumArray[*]}; t++)); do
+                                [[ "${BreakHelpNumArray[t]}" = "$j" ]] && continue 2
+                            done
+                            tmp_for_other="$tmp_for_other@\${$config_name_my$j}"
+                        else
+                            echo -e "\n#【`date +%X`】 变量值填写不规范，请检查后重试！"
+                            tmp_for_other="$tmp_for_other@\${$config_name_my$j}"
+                        fi
+                    else
+                        tmp_for_other="$tmp_for_other@\${$config_name_my$j}"
+                    fi
+                done
+                echo "${config_name_for_other}1=\"$tmp_for_other\"" | perl -pe "s|($config_name_for_other\d+=\")@|\1|"
+                for ((m = 1; m < ${#pt_pin[*]}; m++)); do
+                    j=$((m + 1))
+                    echo "$config_name_for_other$j=\"$tmp_for_other\"" | perl -pe "s|($config_name_for_other\d+=\")@|\1|"
+                done
+                ;;
+
+            1) ## 均等助力
+                HelpTemp="均等助力"
+                echo -e "\n## 采用\"$HelpTemp\"互助模板："
+                for ((m = 0; m < ${#pt_pin[*]}; m++)); do
+                    tmp_for_other=""
+                    j=$((m + 1))
+                    for ((n = $m; n < $(($user_sum + $m)); n++)); do
+                        [[ $m -eq $n ]] && continue
+                        if [[ $((n + 1)) -le $user_sum ]]; then
+                            k=$((n + 1))
+                        else
+                            k=$((n + 1 - $user_sum))
+                        fi
+                        if [[ $BreakHelpType = "1" ]]; then
+                            if [ "$BreakHelpNumVerify" = "" ]; then
+                                for ((t = 0; t < ${#BreakHelpNumArray[*]}; t++)); do
+                                    [[ "${BreakHelpNumArray[t]}" = "$k" ]] && continue 2
+                                done
+                                tmp_for_other="$tmp_for_other@\${$config_name_my$k}"
+                            else
+                                echo -e "\n#【`date +%X`】 变量值填写不规范，请检查后重试！"
+                                tmp_for_other="$tmp_for_other@\${$config_name_my$k}"
+                            fi
+                        else
+                            tmp_for_other="$tmp_for_other@\${$config_name_my$k}"
+                        fi
+                    done
+                    echo "$config_name_for_other$j=\"$tmp_for_other\"" | perl -pe "s|($config_name_for_other\d+=\")@|\1|"
+                done
+                ;;
+
+            2) ## 本套脚本内账号间随机顺序助力
+                HelpTemp="随机顺序"
+                echo -e "\n## 采用\"$HelpTemp\"互助模板："
+                for ((m = 0; m < ${#pt_pin[*]}; m++)); do
+                    tmp_for_other=""
+                    random_num_list=$(seq $user_sum | sort -R)
+                    j=$((m + 1))
+                    for n in $random_num_list; do
+                        [[ $j -eq $n ]] && continue
+                        if [[ $BreakHelpType = "1" ]]; then
+                            if [ "$BreakHelpNumVerify" = "" ]; then
+                                for ((t = 0; t < ${#BreakHelpNumArray[*]}; t++)); do
+                                    [[ "${BreakHelpNumArray[t]}" = "$n" ]] && continue 2
+                                done
+                                tmp_for_other="$tmp_for_other@\${$config_name_my$n}"
+                            else
+                                echo -e "\n#【`date +%X`】 变量值填写不规范，请检查后重试！"
+                                tmp_for_other="$tmp_for_other@\${$config_name_my$n}"
+                            fi
+                        else
+                            tmp_for_other="$tmp_for_other@\${$config_name_my$n}"
+                        fi
+                    done
+                    echo "$config_name_for_other$j=\"$tmp_for_other\"" | perl -pe "s|($config_name_for_other\d+=\")@|\1|"
+                done
+                ;;
+
+            *) ## 按编号优先
+                HelpTemp="按编号优先"
+                echo -e "\n## 采用\"$HelpTemp\"互助模板"
+                for ((m = 0; m < ${#pt_pin[*]}; m++)); do
+                    tmp_for_other=""
+                    j=$((m + 1))
+                    for ((n = 0; n < $user_sum; n++)); do
+                        [[ $m -eq $n ]] && continue
+                        k=$((n + 1))
+                        if [[ $BreakHelpType = "1" ]]; then
+                            if [ "$BreakHelpNumVerify" = "" ]; then
+                                for ((t = 0; t < ${#BreakHelpNumArray[*]}; t++)); do
+                                    [[ "${BreakHelpNumArray[t]}" = "$k" ]] && continue 2
+                                done
+                                tmp_for_other="$tmp_for_other@\${$config_name_my$k}"
+                            else
+                                echo -e "\n#【`date +%X`】 变量值填写不规范，请检查后重试！"
+                                tmp_for_other="$tmp_for_other@\${$config_name_my$k}"
+                            fi
+                        else
+                            tmp_for_other="$tmp_for_other@\${$config_name_my$k}"
+                        fi
+                    done
+                    echo "$config_name_for_other$j=\"$tmp_for_other\"" | perl -pe "s|($config_name_for_other\d+=\")@|\1|"
+                done
+                ;;
+            esac
+        fi
+    else
+        echo "#【`date +%X`】 未运行过 $task_name.js 脚本，未产生日志"
+    fi
+}
+
+## 汇总输出
+export_all_codes() {
+    gen_pt_pin_array
+    [[ $DEBUG = "1" ]] && echo -e "\n#【`date +%X`】 当前 code.sh 的线程数量：$ps_num"
+    [[ $DEBUG = "1" ]] && echo -e "\n#【`date +%X`】 预设的 JD_COOKIE 数量：`echo $JD_COOKIE | grep -o 'pt_key' | wc -l`"
+    [[ $DEBUG = "1" ]] && echo -e "\n#【`date +%X`】 预设的 JD_COOKIE 环境变量数量：`echo $JD_COOKIE | sed 's/&/\n/g' | wc -l`"
+    [[ $DEBUG = "1" && "$(echo $JD_COOKIE | sed 's/&/\n/g' | wc -l)" = "1" && "$(echo $JD_COOKIE | grep -o 'pt_key' | wc -l)" -gt 1 ]] && echo -e "\n#【`date +%X`】 检测到您将多个 COOKIES 填写到单个环境变量值，请注意将各 COOKIES 采用 & 分隔，否则将无法完整输出互助码及互助规则！"
+    echo -e "\n#【`date +%X`】 从日志提取互助码，编号和配置文件中Cookie编号完全对应，如果为空就是所有日志中都没有。\n\n#【`date +%X`】 即使某个MyXxx变量未赋值，也可以将其变量名填在ForOtherXxx中，jtask脚本会自动过滤空值。\n"
+    if [[ $DiyHelpType = "1" ]]; then
+        echo -e "#【`date +%X`】 您已启用指定活动采用指定互助模板功能！"
+    else
+        echo -n "#【`date +%X`】 您选择的互助码模板为："
+        case $HelpType in
+        0)
+            echo "所有账号助力码全部一致。"
+            ;;
+        1)
+            echo "所有账号机会均等助力。"
+            ;;
+        2)
+            echo "本套脚本内账号间随机顺序助力。"
+            ;;
+    	*)
+            echo "按账号编号优先。"
+            ;;
+        esac
+    fi
+    [[ $BreakHelpType = "1" ]] && echo -e "\n#【`date +%X`】 您已启用屏蔽模式，账号 $BreakHelpNum 将不被助力！"
+    if [ "$ps_num" -gt $proc_num ]; then
+        echo -e "\n#【`date +%X`】 检测到 code.sh 的线程过多 ，请稍后再试！"
+        exit
+    elif [ -z $repo ]; then
+        echo -e "\n#【`date +%X`】 未检测到兼容的活动脚本日志，无法读取互助码，退出！"
+        exit
+    else
+        echo -e "\n#【`date +%X`】 默认调用 $repo 的脚本日志，格式化导出互助码，生成互助规则！"
+        dump_user_info
+        for ((i = 0; i < ${#name_js[*]}; i++)); do
+            echo -e "\n## ${name_chinese[i]}："
+            export_codes_sub "${name_js[i]}" "${name_config[i]}" "${name_chinese[i]}"
+        done
+    fi
+}
+
+#更新配置文件中互助码的函数
+help_codes(){
+local envs=$(eval echo "\$JD_COOKIE")
+local array=($(echo $envs | sed 's/&/ /g'))
+local user_sum=${#array[*]}
+local config_name=$1
+local chinese_name=$2
+local config_name_my=My$config_name
+local config_name_for_other=ForOther$config_name
+local ShareCode_dir="$dir_log/.ShareCode"
+local ShareCode_log="$ShareCode_dir/$config_name.log"
+local i j k
+
+#更新配置文件中的互助码
+[[ ! -d $ShareCode_dir ]] && mkdir -p $ShareCode_dir
+[[ "$1" = "TokenJxnc" ]] && config_name_my=$1
+if [ ! -f $ShareCode_log ] || [ -z "$(cat $ShareCode_log | grep "^$config_name_my\d")" ]; then
+   echo -e "\n## $chinese_name\n${config_name_my}1=''\n" >> $ShareCode_log
+fi
+for ((i=1; i<=200; i++)); do
+    local new_code="$(cat $latest_log_path | grep "^$config_name_my$i=.\+'$" | sed "s/\S\+'\([^']*\)'$/\1/")"
+    local old_code="$(cat $ShareCode_log | grep "^$config_name_my$i=.\+'$" | sed "s/\S\+'\([^']*\)'$/\1/")"
+    if [[ $i -le $user_sum ]]; then
+        if [ -z "$(grep "^$config_name_my$i" $ShareCode_log)" ]; then
+            sed -i "/^$config_name_my$[$i-1]='.*'/ s/$/\n$config_name_my$i=\'\'/" $ShareCode_log
+        fi
+        if [ "$new_code" != "$old_code" ]; then
+            if [[ "$new_code" != "undefined" ]] && [[ "$new_code" != "{}" ]]; then
+                sed -i "s/^$config_name_my$i='$old_code'$/$config_name_my$i='$new_code'/" $ShareCode_log
+            fi
+        fi
+    elif [[ $i -gt $user_sum ]] && [[ $i -gt 1 ]]; then
+        sed -i "/^$config_name_my$i/d" $ShareCode_log
+    elif [[ $i -eq 1 ]] && [[ -z "$new_code" ]]; then
+        sed -i "s/^$config_name_my$i='\S*'$/$config_name_my$i=''/" $ShareCode_log
+    fi
+done
+sed -i "1c ## 上次导入时间：$(date +%Y年%m月%d日\ %X)" $ShareCode_log
+}
+
+#更新配置文件中互助规则的函数
+help_rules(){
+local envs=$(eval echo "\$JD_COOKIE")
+local array=($(echo $envs | sed 's/&/ /g'))
+local user_sum=${#array[*]}
+local config_name=$1
+local chinese_name=$2
+local config_name_my=My$config_name
+local config_name_for_other=ForOther$config_name
+local ShareCode_dir="$dir_log/.ShareCode"
+local ShareCode_log="$ShareCode_dir/$config_name.log"
+local i j k
+
+#更新配置文件中的互助规则
+if [ -z "$(cat $ShareCode_log | grep "^$config_name_for_other\d")" ]; then
+   echo -e "${config_name_for_other}1=\"\"" >> $ShareCode_log
+fi
+for ((j=1; j<=200; j++)); do
+    local new_rule="$(cat $latest_log_path | grep "^$config_name_for_other$j=.\+\"$" | sed "s/\S\+\"\([^\"]*\)\"$/\1/")"
+    local old_rule="$(cat $ShareCode_log | grep "^$config_name_for_other$j=.\+\"$" | sed "s/\S\+\"\([^\"]*\)\"$/\1/")"
+    if [[ $j -le $user_sum ]]; then
+        if [ -z "$(grep "^$config_name_for_other$j" $ShareCode_log)" ]; then
+            sed -i "/^$config_name_for_other$[$j-1]=".*"/ s/$/\n$config_name_for_other$j=\"\"/" $ShareCode_log
+        fi
+        if [ "$new_rule" != "$old_rule" ]; then
+            sed -i "s/^$config_name_for_other$j=\"$old_rule\"$/$config_name_for_other$j=\"$new_rule\"/" $ShareCode_log
+        fi
+    elif [[ $j -gt $user_sum ]] && [[ $j -gt 1 ]]; then
+        sed -i "/^$config_name_for_other$j/d" $ShareCode_log
+    elif [[ $j -eq 1 ]] && [[ -z "$new_rule" ]]; then
+        sed -i "s/^$config_name_for_other$j=\"\S*\"$/$config_name_for_other$j=\"\"/" $ShareCode_log
+    fi
+done
+sed -i "1c ## 上次导入时间：$(date +%Y年%m月%d日\ %X)" $ShareCode_log
+}
+
+export_codes_sub_only(){
+    if [ "$(cat $dir_scripts/"$repo"_jd_cfd.js | grep "// console.log(\`token")" != "" ]; then
+        echo -e "\n# 正在修改 "$repo"_jd_cfd.js ，待完全运行 "$repo"_jd_cfd.js 后即可输出 token ！"
+    fi
+    sed -i 's/.*\(c.*log\).*\(${JSON.*token)}\).*/      \1(\`\\n【京东账号${$.index}（${$.UserName}）的京喜token好友互助码】\2\\n\`)/g' /ql/scripts/*_jd_cfd.js
+    local task_name=$1
+    local config_name=$2
+    local chinese_name=$3
+    local i j k m n pt_pin_in_log code tmp_grep tmp_my_code tmp_for_other user_num random_num_list
+    local envs=$(eval echo "\$JD_COOKIE")
+    local array=($(echo $envs | sed 's/&/ /g'))
+    local user_sum=${#array[*]}
+    if cd $dir_log/$task_name &>/dev/null && [[ $(ls) ]]; then
+        ## 寻找所有互助码以及对应的pt_pin
+        i=0
+        pt_pin_in_log=()
+        code=()
+        pt_pin_and_code=$(ls -r *.log | xargs awk -v var="的$chinese_name好友互助码" 'BEGIN{FS="[（ ）】]+"; OFS="&"} $3~var {print $2,$4}')
+        for line in $pt_pin_and_code; do
+            pt_pin_in_log[i]=$(echo $line | awk -F "&" '{print $1}')
+            code[i]=$(echo $line | awk -F "&" '{print $2}')
+            let i++
+        done
+
+        ## 输出互助码
+        if [[ ${#code[*]} -gt 0 ]]; then
+            for ((m = 0; m < ${#pt_pin[*]}; m++)); do
+                tmp_my_code=""
+                j=$((m + 1))
+                for ((n = 0; n < ${#code[*]}; n++)); do
+                    if [[ ${pt_pin[m]} == ${pt_pin_in_log[n]} ]]; then
+                        tmp_my_code=${code[n]}
+                        break
+                    fi
+                done
+                echo "$config_name$j='$tmp_my_code'"
+            done
+        else
+            echo "## 从日志中未找到任何互助码"
+        fi
+fi
+}
+
+#更新互助码和互助规则
+update_help(){
+case $UpdateType in
+    1)
+        if [ "$ps_num" -le $proc_num ] && [ -f $latest_log_path ]; then
+            backup_del
+            echo -e "\n#【`date +%X`】 开始更新配置文件的互助码和互助规则"
+            for ((i = 0; i < ${#name_config[*]}; i++)); do
+                help_codes "${name_config[i]}" "${name_chinese[i]}"
+                [[ "${name_config[i]}" != "TokenJxnc" ]] && help_rules "${name_config[i]}" "${name_chinese[i]}"
+            done
+            echo -e "\n#【`date +%X`】 配置文件的互助码和互助规则已完成更新"
+        elif [ ! -f $latest_log_path ]; then
+            echo -e "\n#【`date +%X`】 日志文件不存在，请检查后重试！"
+        fi
+        ;;
+    2)
+        if [ "$ps_num" -le $proc_num ] && [ -f $latest_log_path ]; then
+            backup_del
+            echo -e "\n#【`date +%X`】 开始更新配置文件的互助码，不更新互助规则"
+            for ((i = 0; i < ${#name_config[*]}; i++)); do
+                help_codes "${name_config[i]}" "${name_chinese[i]}"
+            done
+            echo -e "\n#【`date +%X`】 配置文件的互助码已完成更新"
+        elif [ ! -f $latest_log_path ]; then
+            echo -e "\n#【`date +%X`】 日志文件不存在，请检查后重试！"
+        fi
+        ;;
+    3)
+        if [ "$ps_num" -le $proc_num ] && [ -f $latest_log_path ]; then
+            backup_del
+            echo -e "\n#【`date +%X`】 开始更新配置文件的互助规则，不更新互助码"
+            for ((i = 0; i < ${#name_config[*]}; i++)); do
+                [[ "${name_config[i]}" != "TokenJxnc" ]] && help_rules "${name_config[i]}" "${name_chinese[i]}"
+            done
+            echo -e "\n#【`date +%X`】 配置文件的互助规则已完成更新"
+        elif [ ! -f $latest_log_path ]; then
+            echo -e "\n#【`date +%X`】 日志文件不存在，请检查后重试！"
+        fi
+        ;;
+    *)
+        echo -e "\n#【`date +%X`】 您已设置不更新配置文件的互助码和互助规则，跳过更新！"
+        ;;
+esac
+}
+
+check_jd_cookie(){
+    local test_connect="$(curl -I -s --connect-timeout 5 https://bean.m.jd.com/bean/signIndex.action -w %{http_code} | tail -n1)"
+    local test_jd_cookie="$(curl -s --noproxy "*" "https://bean.m.jd.com/bean/signIndex.action" -H "cookie: $1")"
+    if [ "$test_connect" -eq "302" ]; then
+        [[ "$test_jd_cookie" ]] && echo "(COOKIE 有效)" || echo "(COOKIE 已失效)"
+    else
+        echo "(API 连接失败)"
+    fi
+}
+
+dump_user_info(){
+echo -e "\n## 账号用户名及 COOKIES 整理如下："
+local envs=$(eval echo "\$JD_COOKIE")
+local array=($(echo $envs | sed 's/&/ /g'))
+    for ((m = 0; m < ${#pt_pin[*]}; m++)); do
+        j=$((m + 1))
+        echo -e "## 用户名 $j：${pt_pin[m]} 备注：${remark_name[m]} `check_jd_cookie ${array[m]}`\nCookie$j=\"${array[m]}\""
+    done
+}
+
+backup_del(){
+[[ ! -d $dir_log/.bak_ShareCode ]] && mkdir -p $dir_log/.bak_ShareCode
+local bak_ShareCode_full_path_list=$(find $dir_log/.bak_ShareCode/ -name "*.log")
+local diff_time
+if [[ $BACKUP = "1" ]]; then
+    for ((i = 0; i < ${#name_config[*]}; i++)); do
+        [[ -f $dir_log/.ShareCode/${name_config[i]}.log ]] && cp $dir_log/.ShareCode/${name_config[i]}.log $dir_log/.bak_ShareCode/${name_config[i]}_`date "+%Y-%m-%d-%H-%M-%S"`.log
+    done
+fi
+if [[ $CLEANBAK = "1" ]]; then
+    for log in $bak_ShareCode_full_path_list; do
+        local log_date=$(echo $log | awk -F "_" '{print $NF}' | cut -c1-10)
+        if [[ $(date +%s -d $log_date 2>/dev/null) ]]; then
+            if [[ $is_macos -eq 1 ]]; then
+                diff_time=$(($(date +%s) - $(date -j -f "%Y-%m-%d" "$log_date" +%s)))
+            else
+                diff_time=$(($(date +%s) - $(date +%s -d "$log_date")))
+            fi
+            [[ $diff_time -gt $(($CLEANBAK_DAYS * 86400)) ]] && rm -vf $log
+        fi
+    done
+fi
+}
+
+install_dependencies_normal(){
+    for i in $@; do
+        case $i in
+            canvas)
+                cd /ql/scripts
+                if [[ "$(echo $(npm ls $i) | grep ERR)" != "" ]]; then
+                    npm uninstall $i
+                fi
+                if [[ "$(npm ls $i)" =~ (empty) ]]; then
+                    apk add --no-cache build-base g++ cairo-dev pango-dev giflib-dev && npm i $i --prefix /ql/scripts --build-from-source
+                fi
+                ;;
+            *)
+                if [[ "$(npm ls $i)" =~ $i ]]; then
+                    npm uninstall $i
+                elif [[ "$(echo $(npm ls $i -g) | grep ERR)" != "" ]]; then
+                    npm uninstall $i -g
+                fi
+                if [[ "$(npm ls $i -g)" =~ (empty) ]]; then
+                    [[ $i = "typescript" ]] && npm i $i -g --force || npm i $i -g
+                fi
+                ;;
+        esac
+    done
+}
+
+install_dependencies_force(){
+    for i in $@; do
+        case $i in
+            canvas)
+                cd /ql/scripts
+                if [[ "$(npm ls $i)" =~ $i && "$(echo $(npm ls $i) | grep ERR)" != "" ]]; then
+                    npm uninstall $i
+                    rm -rf /ql/scripts/node_modules/$i
+                    rm -rf /usr/local/lib/node_modules/lodash/*
+                fi
+                if [[ "$(npm ls $i)" =~ (empty) ]]; then
+                    apk add --no-cache build-base g++ cairo-dev pango-dev giflib-dev && npm i $i --prefix /ql/scripts --build-from-source --force
+                fi
+                ;;
+            *)
+                cd /ql/scripts
+                if [[ "$(npm ls $i)" =~ $i ]]; then
+                    npm uninstall $i
+                    rm -rf /ql/scripts/node_modules/$i
+                    rm -rf /usr/local/lib/node_modules/lodash/*
+                elif [[ "$(npm ls $i -g)" =~ $i && "$(echo $(npm ls $i -g) | grep ERR)" != "" ]]; then
+                    npm uninstall $i -g
+                    rm -rf /ql/scripts/node_modules/$i
+                    rm -rf /usr/local/lib/node_modules/lodash/*
+                fi
+                if [[ "$(npm ls $i -g)" =~ (empty) ]]; then
+                    npm i $i -g --force
+                fi
+                ;;
+        esac
+    done
+}
+
+install_dependencies_all(){
+    install_dependencies_normal $package_name
+    for i in $package_name; do
+        {install_dependencies_force $i} &
+    done
+}
+
+kill_proc(){
+ps -ef|grep "$1"|grep -Ev "$2"|awk '{print $1}'|xargs kill -9
+}
+
+## 执行并写入日志
+kill_proc "code.sh" "grep|$$" >/dev/null 2>&1
+[[ $FixDependType = "1" ]] && [[ "$ps_num" -le $proc_num ]] && install_dependencies_all >/dev/null 2>&1 &
+latest_log=$(ls -r $dir_code | head -1)
+latest_log_path="$dir_code/$latest_log"
+ps_num="$(ps | grep code.sh | grep -v grep | wc -l)"
+export_all_codes | perl -pe "{s|京东种豆|种豆|; s|crazyJoy任务|疯狂的JOY|}"
+sleep 5
+update_help
+
+## 修改curtinlv入会领豆配置文件的参数
+[[ -f /ql/repo/curtinlv_JD-Script/OpenCard/OpenCardConfig.ini ]] && sed -i "4c JD_COOKIE = '$(echo $JD_COOKIE | sed "s/&/ /g; s/\S*\(pt_key=\S\+;\)\S*\(pt_pin=\S\+;\)\S*/\1\2/g;" | perl -pe "s| |&|g")'" /ql/repo/curtinlv_JD-Script/OpenCard/OpenCardConfig.ini

--- a/shareCode/task_before.sh
+++ b/shareCode/task_before.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+
+# 基于 https://t.me/update_help/42?single
+
+# Build 20211009-001-test
+
+name_js=(
+  jd_fruit
+  jd_pet
+  jd_plantBean
+  jd_dreamFactory
+  jd_jdfactory
+  jd_crazy_joy
+  jd_jdzz
+  jd_jxnc
+  jd_bookshop
+  jd_cash
+  jd_sgmh
+  jd_cfd
+  jd_health
+  jd_carnivalcity
+  jd_city
+  jd_moneyTree_heip
+  jd_cfdtx
+)
+name_config=(
+  Fruit
+  Pet
+  Bean
+  DreamFactory
+  JdFactory
+  Joy
+  Jdzz
+  Jxnc
+  BookShop
+  Cash
+  Sgmh
+  Cfd
+  Health
+  Carni
+  City
+  MoneyTree
+  TokenJxnc
+)
+env_name=(
+  FRUITSHARECODES                     ## 1、东东农场互助码
+  PETSHARECODES                       ## 2、东东萌宠互助码
+  PLANT_BEAN_SHARECODES               ## 3、种豆得豆互助码
+  DREAM_FACTORY_SHARE_CODES           ## 4、京喜工厂互助码
+  DDFACTORY_SHARECODES                ## 5、东东工厂互助码
+  JDJOY_SHARECODES                    ## 6、疯狂的JOY互助码
+  JDZZ_SHARECODES                     ## 7、京东赚赚互助码
+  JXNC_SHARECODES                     ## 8、京喜农场助力码
+  BOOKSHOP_SHARECODES                 ## 9、口袋书店互助码
+  JD_CASH_SHARECODES                  ## 10、签到领现金互助码
+  JDSGMH_SHARECODES                   ## 11、闪购盲盒互助码
+  JDCFD_SHARECODES                    ## 12、京喜财富岛互助码
+  JDHEALTH_SHARECODES                 ## 13、东东健康社区互助码
+  JD818_SHARECODES                    ## 14、京东手机狂欢城互助码
+  CITY_SHARECODES                     ## 15、城城领现金互助码
+  MONEYTREE_SHARECODES                ## 16、摇钱树
+  JXNCTOKENS                          ## 17、京喜Token(京喜财富岛提现用)
+)
+var_name=(
+  ForOtherFruit                       ## 1、东东农场互助规则
+  ForOtherPet                         ## 2、东东萌宠互助规则
+  ForOtherBean                        ## 3、种豆得豆互助规则
+  ForOtherDreamFactory                ## 4、京喜工厂互助规则
+  ForOtherJdFactory                   ## 5、东东工厂互助规则
+  ForOtherJoy                         ## 6、疯狂的JOY互助规则
+  ForOtherJdzz                        ## 7、京东赚赚互助规则
+  ForOtherJxnc                        ## 8、京喜农场助力码
+  ForOtherBookShop                    ## 9、口袋书店互助规则
+  ForOtherCash                        ## 10、签到领现金互助规则
+  ForOtherSgmh                        ## 11、闪购盲盒互助规则
+  ForOtherCfd                         ## 12、京喜财富岛互助规则
+  ForOtherHealth                      ## 13、东东健康社区互助规则
+  ForOtherCarni                       ## 14、京东手机狂欢城互助规则
+  ForOtherCity                        ## 15、城城领现金互助规则
+  ForOtherMoneyTree                   ## 16、摇钱树
+  TokenJxnc                           ## 17、京喜Token(京喜财富岛提现用)
+)
+
+## 临时屏蔽某账号运行活动脚本(账号序号匹配)
+TempBlock_JD_COOKIE(){
+    source $file_env
+    local TempBlockCookieInterval="$(echo $TempBlockCookie | perl -pe "{s|~|-|; s|_|-|}" | sed 's/\(\d\+\)-\(\d\+\)/{\1..\2}/g')"
+    local TempBlockCookieArray=($(eval echo $TempBlockCookieInterval))
+    local envs=$(eval echo "\$JD_COOKIE")
+    local array=($(echo $envs | sed 's/&/ /g'))
+    local user_sum=${#array[*]}
+    local m n t
+    for ((m = 1; m <= $user_sum; m++)); do
+        n=$((m - 1))
+        for ((t = 0; t < ${#TempBlockCookieArray[*]}; t++)); do
+            [[ "${TempBlockCookieArray[t]}" = "$m" ]] && unset array[n]
+        done
+    done
+    jdCookie=$(echo ${array[*]} | sed 's/\ /\&/g')
+    [[ ! -z $jdCookie ]] && export JD_COOKIE="$jdCookie"
+    temp_user_sum=${#array[*]}
+}
+
+## 临时屏蔽某账号运行活动脚本(pt_pin匹配)
+TempBlock_JD_PT_PIN(){
+    [[ -z $JD_COOKIE ]] && source $file_env
+    local TempBlockPinArray=($TempBlockPin)
+    local envs=$(eval echo "\$JD_COOKIE")
+    local array=($(echo $envs | sed 's/&/ /g'))
+    local i m n t pt_pin_temp pt_pin_temp_block
+    for i in "${!array[@]}"; do
+        pt_pin_temp=$(echo ${array[i]} | perl -pe "{s|.*pt_pin=([^; ]+)(?=;?).*|\1|; s|%|\\\x|g}")
+        [[ $pt_pin_temp == *\\x* ]] && pt_pin[i]=$(printf $pt_pin_temp) || pt_pin[i]=$pt_pin_temp
+        for n in "${!TempBlockPinArray[@]}"; do
+            pt_pin_temp_block=$(echo ${TempBlockPinArray[n]} | perl -pe "{s|%|\\\x|g}")
+            [[ $pt_pin_temp_block == *\\x* ]] && pt_pin_block[n]=$(printf $pt_pin_temp_block) || pt_pin_block[n]=$pt_pin_temp_block
+            [[ "${pt_pin[i]}" =~ "${pt_pin_block[n]}" ]] && unset array[i]
+        done
+    done
+    jdCookie=$(echo ${array[*]} | sed 's/\ /\&/g')
+    [[ ! -z $jdCookie ]] && export JD_COOKIE="$jdCookie"
+    temp_user_sum=${#array[*]}
+}
+
+## 随机账号运行活动
+Random_JD_COOKIE(){
+    [[ -z $JD_COOKIE ]] && source $file_env
+    local envs=$(eval echo "\$JD_COOKIE")
+    local array=($(echo $envs | sed 's/&/ /g'))
+    local user_sum=${#array[*]}
+    local combined_all
+    if [[ $RandomMode = "1" ]]; then
+        [[ ! $ran_num ]] && ran_num=$user_sum
+        if [ $(echo $ran_num|grep '[0-9]') ]; then
+            [[ $ran_num -gt $user_sum || $ran_num -lt 2 ]] && ran_num=$user_sum
+            ran_sub="$(seq $user_sum | sort -R | head -$ran_num)"
+            for i in $ran_sub; do
+                tmp="${array[i]}"
+                combined_all="$combined_all&$tmp"
+            done
+            jdCookie=$(echo $combined_all | sed 's/^&//g')
+            [[ ! -z $jdCookie ]] && export JD_COOKIE="$jdCookie"
+        fi
+    fi
+}
+
+## 组队任务
+combine_team(){
+    p=$1
+    q=$2
+    export jd_zdjr_activityId=$3
+    export jd_zdjr_activityUrl=$4
+}
+
+team_task(){
+    [[ -z $JD_COOKIE ]] && source $file_env
+    local envs=$(eval echo "\$JD_COOKIE")
+    local array=($(echo $envs | sed 's/&/ /g'))
+    local user_sum=${#array[*]}
+    local i j k x y p q
+    local scr=$scr_name
+    local teamer_array=($teamer_num)
+    local team_array=($team_num)
+    if [[ -f /ql/scripts/$scr ]]; then
+        for ((i=0; i<${#teamer_array[*]}; i++)); do
+            combine_team ${teamer_array[i]} ${team_array[i]} ${activityId[i]} ${activityUrl[i]}
+            [[ $q -ge $(($user_sum/p)) ]] && q=$(($user_sum/p))
+            for ((m = 0; m < $user_sum; m++)); do
+                j=$((m + 1))
+                x=$((m/q))
+                y=$(((p - 1)*m + 1))
+                COOKIES_HEAD="${array[x]}"
+                COOKIES=""
+                if [[ $j -le $q ]]; then
+                    for ((n = 1; n < $p; n++)); do
+                        COOKIES="$COOKIES&${array[y]}"
+                        let y++
+                    done
+                elif [[ $j -eq $((q + 1)) ]]; then
+                    for ((n = 1; n < $((p-1)); n++)); do
+                        COOKIES_HEAD="${array[x]}&${array[0]}"
+                        COOKIES="$COOKIES&${array[y]}"
+                        let y++
+                    done
+                elif [[ $j -gt $((q + 1)) ]]; then
+                    [[ $((y+1)) -le $user_sum ]] && y=$(((p - 1)*m)) || break
+                    for ((n = $m; n < $((m + p -1)); n++)); do
+                        COOKIES="$COOKIES&${array[y]}"
+                        let y++
+                        [[ $y = $x ]] && y=$((y+1))
+                        [[ $((y+1)) -gt $user_sum ]] && break
+                    done
+                fi
+                result=$(echo -e "$COOKIES_HEAD$COOKIES")
+                if [[ $result ]]; then
+                    export JD_COOKIE=$result
+                    node /ql/scripts/$scr
+                fi
+#               echo $JD_COOKIE
+            done
+        done
+        exit
+    fi
+}
+
+## 组合互助码格式化为全局变量的函数
+combine_sub() {
+    source $file_env
+    local what_combine=$1
+    local combined_all=""
+    local tmp1 tmp2
+    local TempBlockCookieInterval="$(echo $TempBlockCookie | perl -pe "{s|~|-|; s|_|-|}" | sed 's/\(\d\+\)-\(\d\+\)/{\1..\2}/g')"
+    local TempBlockCookieArray=($(eval echo $TempBlockCookieInterval))
+    local envs=$(eval echo "\$JD_COOKIE")
+    local array=($(echo $envs | sed 's/&/ /g'))
+    local user_sum=${#array[*]}
+    local a b i j t sum combined_all
+    for ((i=1; i <= $user_sum; i++)); do
+        local tmp1=$what_combine$i
+        local tmp2=${!tmp1}
+        [[ ${tmp2} ]] && sum=$i || break
+    done
+    [[ ! $sum ]] && sum=$user_sum
+    for ((j = 1; j <= $sum; j++)); do
+        a=$temp_user_sum
+        b=$sum
+        if [[ $a -ne $b ]]; then
+            for ((t = 0; t < ${#TempBlockCookieArray[*]}; t++)); do
+                [[ "${TempBlockCookieArray[t]}" = "$j" ]] && continue 2
+            done
+        fi
+        local tmp1=$what_combine$j
+        local tmp2=${!tmp1}
+        combined_all="$combined_all&$tmp2"
+    done
+    echo $combined_all | perl -pe "{s|^&||; s|^@+||; s|&@|&|g; s|@+&|&|g; s|@+|@|g; s|@+$||}"
+}
+
+## 正常依次运行时，组合互助码格式化为全局变量
+combine_all() {
+    for ((i = 0; i < ${#env_name[*]}; i++)); do
+        result=$(combine_sub ${var_name[i]})
+        if [[ $result ]]; then
+            export ${env_name[i]}="$result"
+        fi
+    done
+}
+
+## 正常依次运行时，组合互助码格式化为全局变量
+combine_only() {
+    for ((i = 0; i < ${#env_name[*]}; i++)); do
+        case $1 in
+            *${name_js[i]}*.js | *${name_js[i]}*.ts)
+	            if [[ -f $dir_log/.ShareCode/${name_config[i]}.log ]]; then
+                    . $dir_log/.ShareCode/${name_config[i]}.log
+                    result=$(combine_sub ${var_name[i]})
+                    if [[ $result ]]; then
+                        # 魔改说明：直接设置在ck超过45时，会导致env过大，部分系统命令无法执行，导致脚本执行失败
+                        #   这里改成设置一个标记，在nodejs中去实际设置环境变量
+                        # export ${env_name[i]}=$result
+                        export ShareCodeConfigName=${name_config[i]}
+                        export ShareCodeEnvName=${env_name[i]}
+                        echo "设置环境变量标记 ShareCodeConfigName=${ShareCodeConfigName} ShareCodeEnvName=${ShareCodeEnvName}, 供nodejs去实际生成互助码环境变量"
+                    fi
+                fi
+                ;;
+           *)
+                export ${env_name[i]}=""
+                ;;
+        esac
+    done
+}
+
+TempBlock_JD_COOKIE && TempBlock_JD_PT_PIN && Random_JD_COOKIE
+
+if [ $scr_name ]; then
+    team_task
+else
+	combine_only "$1"
+fi
+
+#if [[ $(ls $dir_code) ]]; then
+#    latest_log=$(ls -r $dir_code | head -1)
+#    . $dir_code/$latest_log
+#    combine_all
+#fi
+


### PR DESCRIPTION
## 目录
- [目录](#目录)
- [太长不读](#太长不读)
- [最初](#最初)
- [当ck到一定数目后](#当ck到一定数目后)
- [排查定位](#排查定位)
- [现有解决方案](#现有解决方案)
- [新的解决思路](#新的解决思路)
- [最终方案](#最终方案)
- [核心改动代码](#核心改动代码)
  - [shell中设置参数](#shell中设置参数)
  - [nodejs中实际处理](#nodejs中实际处理)
- [效果](#效果)

## 太长不读
复制 task_before.sh 和 code.sh 到config.sh，用法与 https://t.me/update_help/45 中所述完全一致

拉取仓库时，在最后加上 ` && cp /ql/config/jdCookie.js /ql/scripts/shufflewzc_faker2/jdCookie.js`，从而在拉完库时强行将魔改版的该文件覆盖过去。

这里以 shufflewzc/faker2 为例
```shell
ql repo https://ghproxy.com/https://github.com/shufflewzc/faker2.git "jd_|jx_|gua_|jddj_|getJDCookie" "activity|backUp" "^jd[^_]|USER|function|utils|sendNotify.py|sendNotify.js|notify.py|ZooFaker_Necklace.js|JDJRValidator_|sign_graphics_validate|ql" && cp /ql/config/jdCookie.js /ql/scripts/shufflewzc_faker2/jdCookie.js
```

## 最初
之前使用的互助码脚本 task_before.sh 和 code.sh 是从 互助研究院电报群 获取的 
> https://t.me/update_help/41
> https://t.me/update_help/45

在cookie数目较少的情况下，一直运行良好，这里先感谢大佬的无私奉献。

## 当ck到一定数目后
但是，在我拉了更多人一起挂青龙，ck到达89个时，很多脚本开始报 Argument list too long 错误，而且是一些系统命令，比如 timeout、date、cat等报的错，看的我一脸懵逼。
![image](https://user-images.githubusercontent.com/13483212/142473975-5ea3ba0b-08f3-4f91-8e08-e3453edeb641.png)

## 排查定位
于是昨晚在青龙容器里对shell下断点，各种调试，也是一直毫无头绪，后来，在搜到下面这个帖子时，终于明白了这个报错的起因。
> https://stackoverflow.com/a/28865503

task_before.sh在shell环境中设置了一个很大的环境变量，其大小大概为 总ck数目 * 未被屏蔽的ck数目 * 单个互助码的大小，部分活动的互助码大小约为40。
此时如果有80个ck，且全部启用，则大小将是 80 * 80 * 40 = 256000，而系统默认的参数列表大小（包含环境变量）为 $(getconf ARG_MAX) = 131072，
可见远远超出该值。因此后续调用任何系统命令，都将会报出 Argument list too long 而导致后续流程无法正常进行。

## 现有解决方案
昨晚搜了下现有的做法，基本都是分多个青龙容器，每个保持在45个（这样大小约为81000），确保不会报错。这个方法很简洁，但是会带来维护上的麻烦，本来只要部署一套qinglong容器，现在需要维护多套，比较费心力。

## 新的解决思路
昨天最初准备按这套走了，流程都构思完了。后来突然想到一个新思路，现在的问题是shell中设置的env太大了，导致其他流程不能正常执行。那么如果我把设置env的流程挪到nodejs中，不再经由shell的环境，那么shell中执行的其他命令就不会报错了。
有了思路后，问题就简单了。这下只需要把原先task_before.js中执行的解析互助码文件和转换后放入shell环境变量的流程换到nodejs中即可，这样这几十MB的环境变量就不再是作为参数传入了。

## 最终方案
一番处理后，最终就有了下面的流程
task_before.sh 不再直接设置环境变量，而是设置要处理的活动名称和对应互助码文件名称

接下来需要在nodejs中某个地方去接收这两个参数来实际生成。如果仓库完全自己管控，那么直接新增一个模块，在模块内处理后塞入process.env，然后各个脚本中引入即可，与之前表现完全一致。
但是显然这样沟通成本有点高，这里可以取巧，观察可以发现，几乎每个脚本中都有下面这句
```javascript
const jdCookieNode = $.isNode() ? require('./jdCookie.js') : '';
```

所以，我们可以魔改 jdCookie.js 这个文件，自己从基准仓库中复制一份，然后将我们的处理互助码的逻辑加到后面即可，这样就可以实现每个脚本自动调用我们的新流程了。

所以最终就有了下面三个文件
code.sh             原版，负责在 /ql/log/.ShareCode 生成互助码的文件
task_before.sh      魔改版，负责确认当前活动是否需要互助码，若需要，则设置 活动名称ShareCodeConfigName 和 环境变量名称ShareCodeEnvName 这两个环境变量
jdCookie.js         魔改版，判断前面两个环境变量是否存在，若存在，则解析对应活动的互助码文件，按照task_before.sh原有的逻辑转换后放入对应环境变量key中

前两个按原有教程操作即可，魔改版的jdCookie.js在拉库完强行覆盖，也就是在原有ql repo指令后加上下面这句
```shell
&& cp /ql/config/jdCookie.js /ql/scripts/shufflewzc_faker2/jdCookie.js
```

## 核心改动代码
### shell中设置参数
```shell
## 正常依次运行时，组合互助码格式化为全局变量
combine_only() {
    for ((i = 0; i < ${#env_name[*]}; i++)); do
        case $1 in
            *${name_js[i]}*.js | *${name_js[i]}*.ts)
	            if [[ -f $dir_log/.ShareCode/${name_config[i]}.log ]]; then
                    . $dir_log/.ShareCode/${name_config[i]}.log
                    result=$(combine_sub ${var_name[i]})
                    if [[ $result ]]; then
                        # 魔改说明：直接设置在ck超过45时，会导致env过大，部分系统命令无法执行，导致脚本执行失败
                        #   这里改成设置一个标记，在nodejs中去实际设置环境变量
                        # export ${env_name[i]}=$result
                        export ShareCodeConfigName=${name_config[i]}
                        export ShareCodeEnvName=${env_name[i]}
                        echo "设置环境变量标记 ShareCodeConfigName=${ShareCodeConfigName} ShareCodeEnvName=${ShareCodeEnvName}, 供nodejs去实际生成互助码环境变量"
                    fi
                fi
                ;;
           *)
                export ${env_name[i]}=""
                ;;
        esac
    done
}
```

### nodejs中实际处理
```javascript
// 若在task_before.sh 中设置了要设置互助码环境变量的活动名称和环境变量名称信息，则在nodejs中处理，供活动使用
let nameConfig = process.env.ShareCodeConfigName
let envName = process.env.ShareCodeEnvName
if (nameConfig && envName) {
    SetShareCodesEnv(nameConfig, envName)
} else {
    console.debug(`【风之凌殇】 友情提示：当前未设置 ShareCodeConfigName 或 ShareCodeEnvName 环境变量，将不会尝试在nodejs中生成互助码的环境变量。ps: 两个值目前分别为 ${nameConfig} ${envName}`)
}
```

## 效果
自此，即使你的ck很多，也不再用看到下面这一幕了。
![image](https://user-images.githubusercontent.com/13483212/142474215-af41b6c1-acdf-410f-985a-90ebe749103e.png)

而是会看到
![image](https://user-images.githubusercontent.com/13483212/142474100-1c97d031-c49a-44e1-acf6-ac87d8aafdeb.png)