### PR TITLE
feat: 修复并重构 愤怒的锦鲤 活动

### DIFF
--- a/jd_angryKoi.js
+++ b/jd_angryKoi.js
@@ -2,103 +2,283 @@
 愤怒的锦鲤
 更新时间：2021-7-11
 备注：高速并发请求，专治偷助力。在kois环境变量中填入需要助力的pt_pin，有多个请用@符号连接
+
+风之凌殇 魔改版：
+改用以下变量
+#雨露均沾，若配置，则车头外的ck随机顺序，这样可以等概率的随到前面来
+export  FAIR_MODE="true"
+## 设置1个车头，如果有更多个车头，就写对应数目。仅当车头互助满，才会尝试后面的。
+export CHETOU_NUMBER="1"
+
 TG学习交流群：https://t.me/cdles
 5 0 * * * https://raw.githubusercontent.com/cdle/jd_study/main/jd_angryKoi.js
 */
 const $ = new Env("愤怒的锦鲤")
 const JD_API_HOST = 'https://api.m.jd.com/client.action';
-const ua = `jdltapp;iPhone;3.1.0;${Math.ceil(Math.random()*4+10)}.${Math.ceil(Math.random()*4)};${randomString(40)}`
-var kois = process.env.kois ?? ""
+const ua = `jdltapp;iPhone;3.1.0;${Math.ceil(Math.random() * 4 + 10)}.${Math.ceil(Math.random() * 4)};${randomString(40)}`
+let fair_mode = process.env.FAIR_MODE == "true" ? true : false
+let chetou_number = process.env.CHETOU_NUMBER ? Number(process.env.CHETOU_NUMBER) : 0
 let cookiesArr = []
-var helps = [];
-var tools= []
-!(async () => {
-    if(!kois){
-        console.log("请在环境变量中填写需要助力的账号")
-    }
-    requireConfig()
-    for (let i in cookiesArr) {
-        cookie = cookiesArr[i]
-        if(kois.indexOf(cookie.match(/pt_pin=([^; ]+)(?=;?)/) && cookie.match(/pt_pin=([^; ]+)(?=;?)/)[1])!=-1){
-                var num="";
-                for(var g=0;g<6;g++)
-                {
-                     num+=Math.floor(Math.random()*10);
-                }
-            var data = await requestApi('h5launch',cookie,{
-                 "followShop":0,
-                 "random": num,
-                 "log":"42588613~8,~0iuxyee",
-                 "sceneid":"JLHBhPageh5"
-            });
-            switch (data?.data?.result?.status) {
-                case 1://火爆
-                    continue;
-                case 2://已经发起过
-                    break;
-                default:
-                    if(data?.data?.result?.redPacketId){
-                        helps.push({redPacketId: data.data.result.redPacketId, success: false, id: i, cookie: cookie})
-                    }
-                    continue;
-            }   
-            data = await requestApi('h5activityIndex',cookie,{
-                "isjdapp":1
-            });
-            console.log("发起请求")
-            switch (data?.data?.code) {
-                case 20002://已达拆红包数量限制
-                    break;
-                case 10002://活动正在进行，火爆号
-                    break;
-                case 20001://红包活动正在进行，可拆
-                    helps.push({redPacketId: data.data.result.redpacketInfo.id, success: false, id: i, cookie: cookie})
-                    break;
-                default:
-                    break;
-            }
-        }
-        tools.push({id: i, cookie: cookie})   
-    }
-    for(let help of helps){
-        open(help)
-    }
-    await $.wait(60000)
-})()  .catch((e) => {
-    $.log('', `❌ ${$.name}, 失败! 原因: ${e}!`, '')
-  })
-  .finally(() => {
-    $.done();
-  })
+var tools = []
 
-function open(help){
-    var num="";
-    for(var i=0;i<6;i++)
-    {
-        num+=Math.floor(Math.random()*10);
+let notify, allMessage = '';
+
+!(async () => {
+    await requireConfig()
+
+    console.log(`当前配置的车头数目：${chetou_number}，是否开启公平模式：${fair_mode}`)
+
+    console.log("开始获取用于助力的账号列表")
+    for (let i in cookiesArr) {
+        // 将用于助力的账号加入列表
+        tools.push({id: i, assisted: false, cookie: cookiesArr[i]})
+    }
+    console.log(`用于助力的数目为 ${tools.length}`)
+    allMessage += `用于助力的数目为 ${tools.length}\n`
+
+    console.log(`根据配置，计算互助顺序`)
+    cookieIndexOrder = []
+    if (fair_mode) {
+        // 若开启了互助模式，则车头固定在前面
+        for (let i = 0; i < chetou_number; i++) {
+            cookieIndexOrder.push(i)
         }
-    var tool = tools.pop()
-    if(!tool)return
-    if(help.success)return
-    requestApi('jinli_h5assist', tool.cookie, {
-        "redPacketId": help.redPacketId,
-        "followShop":0,
-        "random": num,
-        "log":"42588613~8,~0iuxyee",
-        "sceneid":"JLHBhPageh5"
-    }).then(function(data){
-        desc = data?.data?.result?.statusDesc
-        if (desc && desc.indexOf("助力已满") != -1) {
-            tools.unshift(tool)
-            help.success=true
-        } else if (!data) {
-            tools.unshift(tool)
+        // 后面的随机顺序
+        otherIndexes = []
+        for (let i = chetou_number; i < cookiesArr.length; i++) {
+            otherIndexes.push(i)
         }
-        console.log(`${tool.id}->${help.id}`, desc)   
-        open(help)         
-    })   
+        shuffle(otherIndexes)
+        cookieIndexOrder = cookieIndexOrder.concat(otherIndexes)
+    } else {
+        // 未开启公平模式，则按照顺序互助，前面的先互助满
+        for (let idx = 0; idx < cookiesArr.length; idx++) {
+            cookieIndexOrder.push(idx)
+        }
+    }
+    console.log(`最终互助顺序如下（优先互助满前面的）：\n${cookieIndexOrder}`)
+    allMessage += `今日互助顺序(车头优先，其余等概率随机): ${cookieIndexOrder}\n\n`
+
+    console.log("开始助力")
+    // 最多尝试2*账号数目次，避免无限尝试，保底
+    let remainingTryCount = 2 * cookiesArr.length
+    let helpIndex = 0
+    while (helpIndex < cookiesArr.length && tools.length > 0 && remainingTryCount > 0) {
+        cookieIndex = cookieIndexOrder[helpIndex]
+
+        // 按需获取账号的锦鲤信息
+        let help = await getHelpInfoForCk(cookieIndex, cookiesArr[cookieIndex])
+        if (help) {
+            while (tools.length > 0 && remainingTryCount > 0) {
+                console.info('')
+
+                // 从互助列表末尾取出一个账号，用于尝试助力第一个需要互助的账号
+                let tool = tools.pop()
+
+                // 特殊处理自己的账号
+                if (tool.id == help.id) {
+                    tools.unshift(tool)
+                    console.log(`跳过自己，不尝试使用本账号自己互助（因为必定失败）`)
+                    if (tools.length == 1) {
+                        // 用于互助的队列只剩下自己了，说明自己已经尝试完了，可以留着给下一个人（若有）
+                        break
+                    } else {
+                        // 还有其他的互助码，可以继续尝试本账号
+                        continue
+                    }
+                }
+
+                console.debug(`尝试用 ${tool.id} 账号助力 ${help.id} 账号，用于互助的账号剩余 ${tools.length}`)
+
+                await helpThisUser(help, tool)
+                if (!tool.assisted) {
+                    // 如果没有助力成功，则放入互助列表头部
+                    tools.unshift(tool)
+                }
+                if (help.assist_full) {
+                    console.info(`账号 ${help.id} 助力完成，累计获得 ${help.helpCount} 次互助，将尝试下一个账号`)
+                    break
+                }
+
+                remainingTryCount -= 1
+
+                // 等待一会，避免频繁请求
+                await $.wait(500)
+            }
+        } else {
+            // 获取失败，跳过
+            console.info(`账号 ${cookieIndex} 获取信息失败，具体原因见上一行，将尝试下一个账号`)
+        }
+
+        await appendRewardInfoToNotify(cookiesArr[cookieIndex])
+
+        console.info('\n----------------------------\n')
+        helpIndex++
+    }
+
+    allMessage += "上述今日轮到互助的账号请记得前往 京东app/领券/锦鲤红包 里面手动领取红包"
+
+    // 发送通知
+    if ($.isNode() && allMessage) {
+        await notify.sendNotify(`${$.name}`, `${allMessage}`)
+    }
+})().catch((e) => {
+    $.log('', `❌ ${$.name}, 失败! 原因: ${e}!`, '')
+})
+    .finally(() => {
+        $.done();
+    })
+
+// https://stackoverflow.com/a/2450976
+function shuffle(array) {
+    let currentIndex = array.length, randomIndex;
+
+    // While there remain elements to shuffle...
+    while (currentIndex != 0) {
+        // Pick a remaining element...
+        randomIndex = Math.floor(Math.random() * currentIndex);
+        currentIndex--;
+
+        // And swap it with the current element.
+        [array[currentIndex], array[randomIndex]] = [
+            array[randomIndex], array[currentIndex]];
+    }
+
+    return array;
 }
-function requestApi(functionId, cookie, body = {}) {
+
+async function getHelpInfoForCk(idx, cookie) {
+    console.log(`开始请求第 ${idx} 个账号的信息`)
+
+    var num = "";
+    for (var g = 0; g < 6; g++) {
+        num += Math.floor(Math.random() * 10);
+    }
+    var data = await requestApi('h5launch', cookie, {
+        "followShop": 0,
+        "random": num,
+        "log": "42588613~8,~0iuxyee",
+        "sceneid": "JLHBhPageh5"
+    });
+    switch (data?.data?.result?.status) {
+        case 1://火爆
+            console.debug("被风控，变成黑号了")
+            return;
+        case 2://已经发起过
+            break;
+        default:
+            if (data?.data?.result?.redPacketId) {
+                // 加入help队列
+                return {
+                    redPacketId: data.data.result.redPacketId,
+                    assist_full: false,
+                    id: idx,
+                    cookie: cookie,
+                    helpCount: 0
+                }
+            }
+    }
+    data = await requestApi('h5activityIndex', cookie, {
+        "isjdapp": 1
+    });
+
+    // 打印今日红包概览
+    if (data?.data?.result?.redpacketConfigFillRewardInfo) {
+        let info = data.data.result
+        console.info(`${info.actName} ${info.redpacketInfo.headmanNickName} 已获取红包 ${info.redpacketInfo.packetTotalSum}，剩余可拆红包为 ${info.remainRedpacketNumber}`)
+
+        for (let packetIdx = 0; packetIdx < info.redpacketConfigFillRewardInfo.length; packetIdx++) {
+            let packetInfo = info.redpacketConfigFillRewardInfo[packetIdx]
+
+            console.info(`红包 ${packetIdx + 1} 助力 ${packetInfo.hasAssistNum}/${packetInfo.requireAssistNum} 已获取 ${packetInfo.packetAmount}/${packetInfo.operationWord}`)
+        }
+    }
+
+    switch (data?.data?.code) {
+        case 20002://已达拆红包数量限制
+            console.debug("已领取今天全部红包")
+            break;
+        case 10002://活动正在进行，火爆号
+            console.debug("被风控，变成黑号了")
+            break;
+        case 20001://红包活动正在进行，可拆
+            // 加入help队列
+            return {
+                redPacketId: data.data.result.redpacketInfo.id,
+                assist_full: false,
+                id: idx,
+                cookie: cookie,
+                helpCount: 0
+            }
+        default:
+            break;
+    }
+}
+
+async function appendRewardInfoToNotify(cookie) {
+    data = await requestApi('h5activityIndex', cookie, {
+        "isjdapp": 1
+    });
+
+    // 打印今日红包概览
+    if (data?.data?.result?.redpacketConfigFillRewardInfo) {
+        let info = data.data.result
+        allMessage += `${info.actName} ${info.redpacketInfo.headmanNickName} 已获取红包 ${info.redpacketInfo.packetTotalSum}，剩余可拆红包为 ${info.remainRedpacketNumber}\n`
+
+        let totalAssistNum = 0
+        let totalRequireAssistNum = 0
+        for (let packetIdx = 0; packetIdx < info.redpacketConfigFillRewardInfo.length; packetIdx++) {
+            let packetInfo = info.redpacketConfigFillRewardInfo[packetIdx]
+
+            totalAssistNum += packetInfo.hasAssistNum
+            totalRequireAssistNum += packetInfo.requireAssistNum
+            allMessage += `红包 ${packetIdx + 1} 助力 ${packetInfo.hasAssistNum}/${packetInfo.requireAssistNum} 已获取 ${packetInfo.packetAmount}/${packetInfo.operationWord}\n`
+        }
+
+        allMessage += `总计获得助力 ${totalAssistNum}/${totalRequireAssistNum}\n`
+
+        allMessage += `\n`
+    }
+
+}
+
+async function helpThisUser(help, tool) {
+    // 计算一个用于请求的随机参数
+    var num = "";
+    for (var i = 0; i < 6; i++) {
+        num += Math.floor(Math.random() * 10);
+    }
+
+    // 实际发起请求
+    await requestApi('jinli_h5assist', tool.cookie, {
+        "redPacketId": help.redPacketId,
+        "followShop": 0,
+        "random": num,
+        "log": "42588613~8,~0iuxyee",
+        "sceneid": "JLHBhPageh5"
+    }).then(function (data) {
+        desc = data?.data?.result?.statusDesc
+        if (desc) {
+            if (desc.indexOf("助力成功") != -1) {
+                help.helpCount += 1
+                tool.assisted = true
+            } else if (desc.indexOf("TA的助力已满") != -1) {
+                help.assist_full = true
+            } else {
+                // 不能重复为好友助力哦
+                // 今日助力次数已满
+                // 活动太火爆啦~去看看其他活动吧~
+                tool.assisted = true
+            }
+        } else {
+            // undefined
+            tool.assisted = true
+        }
+        console.log(`${tool.id}->${help.id}`, desc)
+    })
+}
+
+async function requestApi(functionId, cookie, body = {}) {
     return new Promise(resolve => {
         $.post({
             url: `${JD_API_HOST}/api?appid=jd_mp_h5&functionId=${functionId}&loginType=2&client=jd_mp_h5&clientVersion=10.0.5&osVersion=AndroidOS&d_brand=Xiaomi&d_model=Xiaomi`,
@@ -123,7 +303,7 @@ function requestApi(functionId, cookie, body = {}) {
     })
 }
 
-function requireConfig() {
+async function requireConfig() {
     return new Promise(resolve => {
         notify = $.isNode() ? require('./sendNotify') : '';
         const jdCookieNode = $.isNode() ? require('./jdCookie.js') : '';
@@ -133,7 +313,8 @@ function requireConfig() {
                     cookiesArr.push(jdCookieNode[item])
                 }
             })
-            if (process.env.JD_DEBUG && process.env.JD_DEBUG === 'false') console.log = () => {};
+            if (process.env.JD_DEBUG && process.env.JD_DEBUG === 'false') console.log = () => {
+            };
         } else {
             cookiesArr = [$.getdata('CookieJD'), $.getdata('CookieJD2'), ...jsonParse($.getdata('CookiesJD') || "[]").map(item => item.cookie)].filter(item => !!item);
         }
@@ -154,10 +335,12 @@ function randomString(e) {
 
 function Env(t, e) {
     "undefined" != typeof process && JSON.stringify(process.env).indexOf("GIT_HUB") > -1 && process.exit(0);
+
     class s {
         constructor(t) {
             this.env = t
         }
+
         send(t, e = "GET") {
             t = "string" == typeof t ? {
                 url: t
@@ -169,29 +352,37 @@ function Env(t, e) {
                 })
             })
         }
+
         get(t) {
             return this.send.call(this.env, t)
         }
+
         post(t) {
             return this.send.call(this.env, t, "POST")
         }
     }
+
     return new class {
         constructor(t, e) {
             this.name = t, this.http = new s(this), this.data = null, this.dataFile = "box.dat", this.logs = [], this.isMute = !1, this.isNeedRewrite = !1, this.logSeparator = "\n", this.startTime = (new Date).getTime(), Object.assign(this, e), this.log("", `🔔${this.name}, 开始!`)
         }
+
         isNode() {
             return "undefined" != typeof module && !!module.exports
         }
+
         isQuanX() {
             return "undefined" != typeof $task
         }
+
         isSurge() {
             return "undefined" != typeof $httpClient && "undefined" == typeof $loon
         }
+
         isLoon() {
             return "undefined" != typeof $loon
         }
+
         toObj(t, e = null) {
             try {
                 return JSON.parse(t)
@@ -199,6 +390,7 @@ function Env(t, e) {
                 return e
             }
         }
+
         toStr(t, e = null) {
             try {
                 return JSON.stringify(t)
@@ -206,14 +398,17 @@ function Env(t, e) {
                 return e
             }
         }
+
         getjson(t, e) {
             let s = e;
             const i = this.getdata(t);
             if (i) try {
                 s = JSON.parse(this.getdata(t))
-            } catch {}
+            } catch {
+            }
             return s
         }
+
         setjson(t, e) {
             try {
                 return this.setdata(JSON.stringify(t), e)
@@ -221,6 +416,7 @@ function Env(t, e) {
                 return !1
             }
         }
+
         getScript(t) {
             return new Promise(e => {
                 this.get({
@@ -228,6 +424,7 @@ function Env(t, e) {
                 }, (t, s, i) => e(i))
             })
         }
+
         runScript(t, e) {
             return new Promise(s => {
                 let i = this.getdata("@chavy_boxjs_userCfgs.httpapi");
@@ -249,14 +446,17 @@ function Env(t, e) {
                 this.post(n, (t, e, i) => s(i))
             }).catch(t => this.logErr(t))
         }
+
         loaddata() {
-            if (!this.isNode()) return {}; {
+            if (!this.isNode()) return {};
+            {
                 this.fs = this.fs ? this.fs : require("fs"), this.path = this.path ? this.path : require("path");
                 const t = this.path.resolve(this.dataFile),
                     e = this.path.resolve(process.cwd(), this.dataFile),
                     s = this.fs.existsSync(t),
                     i = !s && this.fs.existsSync(e);
-                if (!s && !i) return {}; {
+                if (!s && !i) return {};
+                {
                     const i = s ? t : e;
                     try {
                         return JSON.parse(this.fs.readFileSync(i))
@@ -266,6 +466,7 @@ function Env(t, e) {
                 }
             }
         }
+
         writedata() {
             if (this.isNode()) {
                 this.fs = this.fs ? this.fs : require("fs"), this.path = this.path ? this.path : require("path");
@@ -277,6 +478,7 @@ function Env(t, e) {
                 s ? this.fs.writeFileSync(t, r) : i ? this.fs.writeFileSync(e, r) : this.fs.writeFileSync(t, r)
             }
         }
+
         lodash_get(t, e, s) {
             const i = e.replace(/\[(\d+)\]/g, ".$1").split(".");
             let r = t;
@@ -284,9 +486,11 @@ function Env(t, e) {
                 if (r = Object(r)[t], void 0 === r) return s;
             return r
         }
+
         lodash_set(t, e, s) {
             return Object(t) !== t ? t : (Array.isArray(e) || (e = e.toString().match(/[^.[\]]+/g) || []), e.slice(0, -1).reduce((t, s, i) => Object(t[s]) === t[s] ? t[s] : t[s] = Math.abs(e[i + 1]) >> 0 == +e[i + 1] ? [] : {}, t)[e[e.length - 1]] = s, t)
         }
+
         getdata(t) {
             let e = this.getval(t);
             if (/^@/.test(t)) {
@@ -300,10 +504,12 @@ function Env(t, e) {
             }
             return e
         }
+
         setdata(t, e) {
             let s = !1;
             if (/^@/.test(e)) {
-                const [, i, r] = /^@(.*?)\.(.*?)$/.exec(e), o = this.getval(i), h = i ? "null" === o ? null : o || "{}" : "{}";
+                const [, i, r] = /^@(.*?)\.(.*?)$/.exec(e), o = this.getval(i),
+                    h = i ? "null" === o ? null : o || "{}" : "{}";
                 try {
                     const e = JSON.parse(h);
                     this.lodash_set(e, r, t), s = this.setval(JSON.stringify(e), i)
@@ -314,16 +520,21 @@ function Env(t, e) {
             } else s = this.setval(t, e);
             return s
         }
+
         getval(t) {
             return this.isSurge() || this.isLoon() ? $persistentStore.read(t) : this.isQuanX() ? $prefs.valueForKey(t) : this.isNode() ? (this.data = this.loaddata(), this.data[t]) : this.data && this.data[t] || null
         }
+
         setval(t, e) {
             return this.isSurge() || this.isLoon() ? $persistentStore.write(t, e) : this.isQuanX() ? $prefs.setValueForKey(t, e) : this.isNode() ? (this.data = this.loaddata(), this.data[e] = t, this.writedata(), !0) : this.data && this.data[e] || null
         }
+
         initGotEnv(t) {
             this.got = this.got ? this.got : require("got"), this.cktough = this.cktough ? this.cktough : require("tough-cookie"), this.ckjar = this.ckjar ? this.ckjar : new this.cktough.CookieJar, t && (t.headers = t.headers ? t.headers : {}, void 0 === t.headers.Cookie && void 0 === t.cookieJar && (t.cookieJar = this.ckjar))
         }
-        get(t, e = (() => {})) {
+
+        get(t, e = (() => {
+        })) {
             t.headers && (delete t.headers["Content-Type"], delete t.headers["Content-Length"]), this.isSurge() || this.isLoon() ? (this.isSurge() && this.isNeedRewrite && (t.headers = t.headers || {}, Object.assign(t.headers, {
                 "X-Surge-Skip-Scripting": !1
             })), $httpClient.get(t, (t, s, i) => {
@@ -373,7 +584,9 @@ function Env(t, e) {
                 e(s, i, i && i.body)
             }))
         }
-        post(t, e = (() => {})) {
+
+        post(t, e = (() => {
+        })) {
             if (t.body && t.headers && !t.headers["Content-Type"] && (t.headers["Content-Type"] = "application/x-www-form-urlencoded"), t.headers && delete t.headers["Content-Length"], this.isSurge() || this.isLoon()) this.isSurge() && this.isNeedRewrite && (t.headers = t.headers || {}, Object.assign(t.headers, {
                 "X-Surge-Skip-Scripting": !1
             })), $httpClient.post(t, (t, s, i) => {
@@ -423,6 +636,7 @@ function Env(t, e) {
                 })
             }
         }
+
         time(t, e = null) {
             const s = e ? new Date(e) : new Date;
             let i = {
@@ -438,6 +652,7 @@ function Env(t, e) {
             for (let e in i) new RegExp("(" + e + ")").test(t) && (t = t.replace(RegExp.$1, 1 == RegExp.$1.length ? i[e] : ("00" + i[e]).substr(("" + i[e]).length)));
             return t
         }
+
         msg(e = t, s = "", i = "", r) {
             const o = t => {
                 if (!t) return t;
@@ -476,16 +691,20 @@ function Env(t, e) {
                 t.push(e), s && t.push(s), i && t.push(i), console.log(t.join("\n")), this.logs = this.logs.concat(t)
             }
         }
+
         log(...t) {
             t.length > 0 && (this.logs = [...this.logs, ...t]), console.log(t.join(this.logSeparator))
         }
+
         logErr(t, e) {
             const s = !this.isSurge() && !this.isQuanX() && !this.isLoon();
             s ? this.log("", `❗️${this.name}, 错误!`, t.stack) : this.log("", `❗️${this.name}, 错误!`, t)
         }
+
         wait(t) {
             return new Promise(e => setTimeout(e, t))
         }
+
         done(t = {}) {
             const e = (new Date).getTime(),
                 s = (e - this.startTime) / 1e3;


### PR DESCRIPTION
## 概述
1. 修复未能按预期先执行前面的账号的问题。
2. 增加支持车头和公平模式
3. 完善日志
4. 增加通知

## 修复前
因 open 函数中 requestApi 调用时未加 await 关键词，导致其实际是放入了一个异步队列，而没有等待其执行，导致执行顺序不对。因此会出现下面这一连串的 发起请求， 以及 后续在当前账号尚未被助力满的情况下，就走到了下一个账号

![image](https://user-images.githubusercontent.com/13483212/143673701-ffecc2c4-7c5d-4e53-b09e-c2a94e18f000.png)

## 修复后
确保执行时序，并增加额外的一些日志。
增加车头模式和公平模式。
增加消息通知，方便今日被助力的号知道该去京东app领红包了（原脚本没有领红包操作，我也懒得去抓包弄了）
![image](https://user-images.githubusercontent.com/13483212/143673816-99e8d972-24a2-4f6e-9320-8f88e1f377c7.png)

![image](https://user-images.githubusercontent.com/13483212/143674322-2576a039-2444-46d5-a410-2fb4cf57e2aa.png)

