### PR TITLE
feat: 愤怒的锦鲤新增 自动开红包功能，并调整部分日志

### DIFF
--- a/jd_angryKoi.js
+++ b/jd_angryKoi.js
@@ -4,11 +4,14 @@
 备注：高速并发请求，专治偷助力。在kois环境变量中填入需要助力的pt_pin，有多个请用@符号连接
 
 风之凌殇 魔改版：
+2021.11.27 修复不能正常先满足第一个账号的问题，并添加车头和公平模式
+2021.11.29 增加自动开红包的功能
+
 改用以下变量
 #雨露均沾，若配置，则车头外的ck随机顺序，这样可以等概率的随到前面来
-export  FAIR_MODE="true"
+export  KOI_FAIR_MODE="true"
 ## 设置1个车头，如果有更多个车头，就写对应数目。仅当车头互助满，才会尝试后面的。
-export CHETOU_NUMBER="1"
+export KOI_CHETOU_NUMBER="1"
 
 TG学习交流群：https://t.me/cdles
 5 0 * * * https://raw.githubusercontent.com/cdle/jd_study/main/jd_angryKoi.js
@@ -16,8 +19,8 @@ TG学习交流群：https://t.me/cdles
 const $ = new Env("愤怒的锦鲤")
 const JD_API_HOST = 'https://api.m.jd.com/client.action';
 const ua = `jdltapp;iPhone;3.1.0;${Math.ceil(Math.random() * 4 + 10)}.${Math.ceil(Math.random() * 4)};${randomString(40)}`
-let fair_mode = process.env.FAIR_MODE == "true" ? true : false
-let chetou_number = process.env.CHETOU_NUMBER ? Number(process.env.CHETOU_NUMBER) : 0
+let fair_mode = process.env.KOI_FAIR_MODE == "true" ? true : false
+let chetou_number = process.env.KOI_CHETOU_NUMBER ? Number(process.env.KOI_CHETOU_NUMBER) : 0
 let cookiesArr = []
 var tools = []
 
@@ -37,14 +40,14 @@ let notify, allMessage = '';
     allMessage += `用于助力的数目为 ${tools.length}\n`
 
     console.log(`根据配置，计算互助顺序`)
-    cookieIndexOrder = []
+    let cookieIndexOrder = []
     if (fair_mode) {
         // 若开启了互助模式，则车头固定在前面
         for (let i = 0; i < chetou_number; i++) {
             cookieIndexOrder.push(i)
         }
         // 后面的随机顺序
-        otherIndexes = []
+        let otherIndexes = []
         for (let i = chetou_number; i < cookiesArr.length; i++) {
             otherIndexes.push(i)
         }
@@ -57,66 +60,73 @@ let notify, allMessage = '';
         }
     }
     console.log(`最终互助顺序如下（优先互助满前面的）：\n${cookieIndexOrder}`)
-    allMessage += `今日互助顺序(车头优先，其余等概率随机): ${cookieIndexOrder}\n\n`
+    allMessage += `本次互助顺序(车头优先，其余等概率随机，每次运行都不一样): ${cookieIndexOrder}\n\n`
 
     console.log("开始助力")
     // 最多尝试2*账号数目次，避免无限尝试，保底
     let remainingTryCount = 2 * cookiesArr.length
     let helpIndex = 0
     while (helpIndex < cookiesArr.length && tools.length > 0 && remainingTryCount > 0) {
-        cookieIndex = cookieIndexOrder[helpIndex]
+        let cookieIndex = cookieIndexOrder[helpIndex]
 
-        // 按需获取账号的锦鲤信息
-        let help = await getHelpInfoForCk(cookieIndex, cookiesArr[cookieIndex])
-        if (help) {
-            while (tools.length > 0 && remainingTryCount > 0) {
-                console.info('')
+        try {
+            // 按需获取账号的锦鲤信息
+            let help = await getHelpInfoForCk(cookieIndex, cookiesArr[cookieIndex])
+            if (help) {
+                while (tools.length > 0 && remainingTryCount > 0) {
+                    console.info('')
 
-                // 从互助列表末尾取出一个账号，用于尝试助力第一个需要互助的账号
-                let tool = tools.pop()
+                    // 从互助列表末尾取出一个账号，用于尝试助力第一个需要互助的账号
+                    let tool = tools.pop()
 
-                // 特殊处理自己的账号
-                if (tool.id == help.id) {
-                    tools.unshift(tool)
-                    console.log(`跳过自己，不尝试使用本账号自己互助（因为必定失败）`)
-                    if (tools.length == 1) {
-                        // 用于互助的队列只剩下自己了，说明自己已经尝试完了，可以留着给下一个人（若有）
-                        break
-                    } else {
-                        // 还有其他的互助码，可以继续尝试本账号
-                        continue
+                    // 特殊处理自己的账号
+                    if (tool.id == help.id) {
+                        tools.unshift(tool)
+                        console.log(`跳过自己，不尝试使用本账号自己互助（因为必定失败）`)
+                        if (tools.length == 1) {
+                            // 用于互助的队列只剩下自己了，说明自己已经尝试完了，可以留着给下一个人（若有）
+                            break
+                        } else {
+                            // 还有其他的互助码，可以继续尝试本账号
+                            continue
+                        }
                     }
+
+                    console.debug(`尝试用 ${tool.id} 账号助力 ${help.id} 账号，用于互助的账号剩余 ${tools.length}`)
+
+                    await helpThisUser(help, tool)
+                    if (!tool.assisted) {
+                        // 如果没有助力成功，则放入互助列表头部
+                        tools.unshift(tool)
+                    }
+                    if (help.assist_full) {
+                        console.info(`账号 ${help.id} 助力完成，累计获得 ${help.helpCount} 次互助，将尝试下一个账号`)
+                        break
+                    }
+
+                    remainingTryCount -= 1
+
+                    // 等待一会，避免频繁请求
+                    await $.wait(500)
                 }
-
-                console.debug(`尝试用 ${tool.id} 账号助力 ${help.id} 账号，用于互助的账号剩余 ${tools.length}`)
-
-                await helpThisUser(help, tool)
-                if (!tool.assisted) {
-                    // 如果没有助力成功，则放入互助列表头部
-                    tools.unshift(tool)
-                }
-                if (help.assist_full) {
-                    console.info(`账号 ${help.id} 助力完成，累计获得 ${help.helpCount} 次互助，将尝试下一个账号`)
-                    break
-                }
-
-                remainingTryCount -= 1
-
-                // 等待一会，避免频繁请求
-                await $.wait(500)
+            } else {
+                // 获取失败，跳过
+                console.info(`账号 ${cookieIndex} 获取信息失败，具体原因见上一行，将尝试下一个账号`)
             }
-        } else {
-            // 获取失败，跳过
-            console.info(`账号 ${cookieIndex} 获取信息失败，具体原因见上一行，将尝试下一个账号`)
-        }
 
-        await appendRewardInfoToNotify(cookiesArr[cookieIndex])
+            await appendRewardInfoToNotify(cookieIndex, cookiesArr[cookieIndex])
+        } catch (error) {
+            // 额外捕获异常
+            console.error(`处理当前账号 ${cookieIndex} 时抛异常了，错误为${error}，捕获该异常，确保其他账号可以继续执行~`)
+        }
 
         console.info('\n----------------------------\n')
         helpIndex++
     }
 
-    allMessage += "上述今日轮到互助的账号请记得前往 京东app/领券/锦鲤红包 里面手动领取红包"
+    allMessage += "上述就是本次的幸运锦鲤啦~ 自动开红包流程没出错的话，红包应该已经领到了~不过也可以手动前往 京东app/领券/锦鲤红包 去确认~\n"
+
+    allMessage += "（请以今日0点后第一次运行的消息为准。后续运行只是为了保底，避免第一次因各种未知异常而未完成运行）"
 
     // 发送通知
     if ($.isNode() && allMessage) {
@@ -147,22 +157,36 @@ function shuffle(array) {
     return array;
 }
 
-async function getHelpInfoForCk(idx, cookie) {
-    console.log(`开始请求第 ${idx} 个账号的信息`)
+async function getHelpInfoForCk(cookieIndex, cookie) {
+    console.log(`开始请求第 ${cookieIndex} 个账号的信息`)
 
-    var num = "";
-    for (var g = 0; g < 6; g++) {
-        num += Math.floor(Math.random() * 10);
+    let data;
+    let MAX_TRY = 3
+
+    // 尝试开启今日的红包活动
+    for (let tryIdex = 1; tryIdex <= MAX_TRY; tryIdex++) {
+        var num = "";
+        for (var g = 0; g < 6; g++) {
+            num += Math.floor(Math.random() * 10);
+        }
+        data = await requestApi('h5launch', cookie, {
+            "followShop": 0,
+            "random": num,
+            "log": "42588613~8,~0iuxyee",
+            "sceneid": "JLHBhPageh5"
+        });
+
+        if (data) {
+            break
+        }
+
+        console.error(`[${tryIdex}/${MAX_TRY}] h5launch 请求时似乎出错了，有可能是网络波动，将最多试三次`)
+        await $.wait(5000)
     }
-    var data = await requestApi('h5launch', cookie, {
-        "followShop": 0,
-        "random": num,
-        "log": "42588613~8,~0iuxyee",
-        "sceneid": "JLHBhPageh5"
-    });
+
     switch (data?.data?.result?.status) {
         case 1://火爆
-            console.debug("被风控，变成黑号了")
+            console.debug(`h5launch 被风控，变成黑号了, data=${JSON.stringify(data)}`)
             return;
         case 2://已经发起过
             break;
@@ -172,25 +196,47 @@ async function getHelpInfoForCk(idx, cookie) {
                 return {
                     redPacketId: data.data.result.redPacketId,
                     assist_full: false,
-                    id: idx,
+                    id: cookieIndex,
                     cookie: cookie,
                     helpCount: 0
                 }
             }
     }
-    data = await requestApi('h5activityIndex', cookie, {
-        "isjdapp": 1
-    });
 
-    // 打印今日红包概览
+    // 已开启活动，尝试查询具体信息
+    for (let tryIdex = 1; tryIdex <= MAX_TRY; tryIdex++) {
+        data = await requestApi('h5activityIndex', cookie, {
+            "isjdapp": 1
+        });
+
+        if (data) {
+            break
+        }
+
+        console.error(`[${tryIdex}/${MAX_TRY}] h5activityIndex 请求时似乎出错了，有可能是网络波动，将最多试三次`)
+        await $.wait(5000)
+    }
+
+
     if (data?.data?.result?.redpacketConfigFillRewardInfo) {
+        // 打印今日红包概览
         let info = data.data.result
-        console.info(`${info.actName} ${info.redpacketInfo.headmanNickName} 已获取红包 ${info.redpacketInfo.packetTotalSum}，剩余可拆红包为 ${info.remainRedpacketNumber}`)
+        let headmanNickName = "", packetTotalSum = 0;
+        if (info.redpacketInfo) {
+            headmanNickName = info.redpacketInfo.headmanNickName
+            packetTotalSum = info.redpacketInfo.packetTotalSum
+        }
+        console.info(`【京东账号${cookieIndex + 1}】 ${headmanNickName} 已获取红包 ${packetTotalSum}，剩余可拆红包为 ${calcCanTakeRedpacketCount(info)}`)
 
         for (let packetIdx = 0; packetIdx < info.redpacketConfigFillRewardInfo.length; packetIdx++) {
             let packetInfo = info.redpacketConfigFillRewardInfo[packetIdx]
 
-            console.info(`红包 ${packetIdx + 1} 助力 ${packetInfo.hasAssistNum}/${packetInfo.requireAssistNum} 已获取 ${packetInfo.packetAmount}/${packetInfo.operationWord}`)
+            let status = "已获取"
+            if (packetInfo.hasAssistNum < packetInfo.requireAssistNum) {
+                status = "未获取"
+            }
+
+            console.info(`红包 ${packetIdx + 1} 助力 ${packetInfo.hasAssistNum}/${packetInfo.requireAssistNum} ${status} ${packetInfo.packetAmount || "未开启"}/${packetInfo.operationWord}`)
         }
     }
 
@@ -199,14 +245,14 @@ async function getHelpInfoForCk(idx, cookie) {
             console.debug("已领取今天全部红包")
             break;
         case 10002://活动正在进行，火爆号
-            console.debug("被风控，变成黑号了")
+            console.debug(`h5activityIndex 被风控，变成黑号了, data=${JSON.stringify(data)}`)
             break;
         case 20001://红包活动正在进行，可拆
             // 加入help队列
             return {
                 redPacketId: data.data.result.redpacketInfo.id,
                 assist_full: false,
-                id: idx,
+                id: cookieIndex,
                 cookie: cookie,
                 helpCount: 0
             }
@@ -215,31 +261,101 @@ async function getHelpInfoForCk(idx, cookie) {
     }
 }
 
-async function appendRewardInfoToNotify(cookie) {
-    data = await requestApi('h5activityIndex', cookie, {
+async function appendRewardInfoToNotify(cookieIndex, cookie) {
+    let data = await requestApi('h5activityIndex', cookie, {
         "isjdapp": 1
     });
+
+    // 判断是否有红包可以领
+    if (calcCanTakeRedpacketCount(data?.data?.result) > 0) {
+        let info = data.data.result
+        let headmanNickName = "";
+        if (info.redpacketInfo) {
+            headmanNickName = info.redpacketInfo.headmanNickName
+        }
+
+        let canTakeCount = calcCanTakeRedpacketCount(info)
+        console.info(`【京东账号${cookieIndex + 1}】 ${headmanNickName} 剩余可拆红包为 ${canTakeCount} 个，将尝试领取`)
+        for (let packetIdx = 0; packetIdx < canTakeCount; packetIdx++) {
+            console.info(`[${packetIdx + 1}/${canTakeCount}] 尝试领取红包`)
+            await openRedPacket(cookie)
+
+            // 等待一会，避免请求过快
+            await $.wait(1000)
+        }
+
+        console.info(`领取完毕，重新查询最新锦鲤红包信息`)
+        data = await requestApi('h5activityIndex', cookie, {
+            "isjdapp": 1
+        });
+    }
 
     // 打印今日红包概览
     if (data?.data?.result?.redpacketConfigFillRewardInfo) {
         let info = data.data.result
-        allMessage += `${info.actName} ${info.redpacketInfo.headmanNickName} 已获取红包 ${info.redpacketInfo.packetTotalSum}，剩余可拆红包为 ${info.remainRedpacketNumber}\n`
+        let headmanNickName = "", packetTotalSum = 0;
+        if (info.redpacketInfo) {
+            headmanNickName = info.redpacketInfo.headmanNickName
+            packetTotalSum = info.redpacketInfo.packetTotalSum
+        }
+        allMessage += `【京东账号${cookieIndex + 1}】 ${headmanNickName} 已获取红包 ${packetTotalSum} 元，剩余可拆红包为 ${calcCanTakeRedpacketCount(info)} 个（如开红包流程顺利，这里应该永远是0）\n`
 
         let totalAssistNum = 0
         let totalRequireAssistNum = 0
         for (let packetIdx = 0; packetIdx < info.redpacketConfigFillRewardInfo.length; packetIdx++) {
             let packetInfo = info.redpacketConfigFillRewardInfo[packetIdx]
 
+            let status = ""
+            if (packetInfo.hasAssistNum < packetInfo.requireAssistNum) {
+                status = "未获取"
+            } else {
+                status = "已获取"
+            }
+
             totalAssistNum += packetInfo.hasAssistNum
             totalRequireAssistNum += packetInfo.requireAssistNum
-            allMessage += `红包 ${packetIdx + 1} 助力 ${packetInfo.hasAssistNum}/${packetInfo.requireAssistNum} 已获取 ${packetInfo.packetAmount}/${packetInfo.operationWord}\n`
+            allMessage += `红包 ${packetIdx + 1} 助力 ${packetInfo.hasAssistNum}/${packetInfo.requireAssistNum} ${status} ${packetInfo.packetAmount || "未开启"}/${packetInfo.operationWord}\n`
         }
 
         allMessage += `总计获得助力 ${totalAssistNum}/${totalRequireAssistNum}\n`
 
         allMessage += `\n`
     }
+}
 
+function calcCanTakeRedpacketCount(info) {
+    if (!info?.redpacketConfigFillRewardInfo) {
+        return 0
+    }
+
+    let count = 0
+    for (let packetIdx = 0; packetIdx < info.redpacketConfigFillRewardInfo.length; packetIdx++) {
+        let packetInfo = info.redpacketConfigFillRewardInfo[packetIdx]
+
+        if (packetInfo.hasAssistNum >= packetInfo.requireAssistNum && !packetInfo.packetAmount) {
+            count++
+        }
+    }
+
+    return count
+}
+
+async function openRedPacket(cookie) {
+    var num = "";
+    for (var g = 0; g < 6; g++) {
+        num += Math.floor(Math.random() * 10);
+    }
+    // https://api.m.jd.com/api?appid=jinlihongbao&functionId=h5receiveRedpacketAll&loginType=2&client=jinlihongbao&t=1638189287348&clientVersion=10.2.4&osVersion=-1
+    let resp = await requestApi('h5receiveRedpacketAll', cookie, {
+        "random": num,
+        "log": "42588613~8,~0iuxyee",
+        "sceneid": "JLHBhPageh5"
+    });
+    if (resp?.data?.biz_code == 0) {
+        console.info(`领取到 ${resp.data.result?.discount} 元红包`)
+    } else {
+        console.error(`领取红包失败，结果为 ${JSON.stringify(resp)}`)
+    }
 }
 
 async function helpThisUser(help, tool) {
@@ -257,7 +373,7 @@ async function helpThisUser(help, tool) {
         "log": "42588613~8,~0iuxyee",
         "sceneid": "JLHBhPageh5"
     }).then(function (data) {
-        desc = data?.data?.result?.statusDesc
+        let desc = data?.data?.result?.statusDesc
         if (desc) {
             if (desc.indexOf("助力成功") != -1) {
                 help.helpCount += 1
@@ -281,7 +397,7 @@ async function helpThisUser(help, tool) {
 async function requestApi(functionId, cookie, body = {}) {
     return new Promise(resolve => {
         $.post({
-            url: `${JD_API_HOST}/api?appid=jd_mp_h5&functionId=${functionId}&loginType=2&client=jd_mp_h5&clientVersion=10.0.5&osVersion=AndroidOS&d_brand=Xiaomi&d_model=Xiaomi`,
+            url: `${JD_API_HOST}/api?appid=jinlihongbao&functionId=${functionId}&loginType=2&client=jinlihongbao&clientVersion=10.2.4&osVersion=AndroidOS&d_brand=Xiaomi&d_model=Xiaomi`,
             headers: {
                 "Cookie": cookie,
                 "origin": "https://h5.m.jd.com",
@@ -296,6 +412,7 @@ async function requestApi(functionId, cookie, body = {}) {
                 data = JSON.parse(data)
             } catch (e) {
                 $.logErr('Error: ', e, resp)
+                console.warn(`请求${functionId}失败，resp=${JSON.stringify(resp)}，data=${JSON.stringify(data)}, e=${JSON.stringify(e)}`)
             } finally {
                 resolve(data)
             }
@@ -328,7 +445,7 @@ function randomString(e) {
     let t = "abcdefhijkmnprstwxyz2345678",
         a = t.length,
         n = "";
-    for (i = 0; i < e; i++)
+    for (let i = 0; i < e; i++)
         n += t.charAt(Math.floor(Math.random() * a));
     return n
 }


### PR DESCRIPTION
# 正文
## 现状
上次魔改锦鲤红包脚本后，其能正确地先助力满前面顺序的账号了，但是发现了一个小问题，红包不会自动开启，需要手动去操作。

最开始几天，每天定点手动去点点，点了几天后就开始烦了。此外由于设置了车头+后面随机模式，所以当天随到的人还得自己去看每天第一次通知的锦鲤活动消息来确认自己是否今天轮到了，这就更恶心了。

## 魔改
于是，11.29号花了点时间折腾了下，加上了自动开红包流程。经过几天的测试，处理了发现的一些小问题，顺带改了些其他问题，具体列出如下。

1. 新增自动开红包的功能
2. 调整车头模式的两个变量为 `KOI_FAIR_MODE` 和 `KOI_CHETOU_NUMBER`，避免与其他活动冲突
3. 调整一些日志信息，更加容易理解
4. 通过增加重试机制，兼容开启红包活动时可能因网络波动而失败，导致没有轮到助力的情况

![image](https://user-images.githubusercontent.com/13483212/144743772-1f5def9d-fe9d-4f40-b9be-a4456038ed69.png)