### PR TITLE
修正city互助码解析错误的问题

### DIFF
--- a/jd_city.js
+++ b/jd_city.js
@@ -299,11 +299,7 @@ function shareCodesFormat() {
                }
                if (process.env.CITY_SHARECODES) {
                     console.log('检测到助力码,优先. 内部互助0.01了吧,删了吧.')
-                    if (process.env.CITY_SHARECODES.indexOf('\n') > -1) {
-                         $.newShareCodes = process.env.CITY_SHARECODES.split('\n');
-                    } else {
-                         $.newShareCodes = process.env.CITY_SHARECODES.split('&');
-                    }
+                    $.newShareCodes = $.shareCodesArr[$.index - 1].split('@');
                }
           }
           // if ($.index - 1 == 0) {


### PR DESCRIPTION
原脚本中互助码解析有问题，会导致单个账号的互助码未展开，具体可参考jd_jdfactory.js中的正确处理办法

https://github.com/shufflewzc/faker2/blob/80a44c286dd8febc1b4a4c42fc970b9e3eb03f64/jd_jdfactory.js#L642-L660