### PR TITLE
健康社区兑换京豆任务放到最前面执行

### DIFF
--- a/jd_health.js
+++ b/jd_health.js
@@ -71,6 +71,10 @@ const JD_API_HOST = "https://api.m.jd.com/";
 
 async function main() {
   try {
+    if (reward) {
+      await getCommodities()
+    }
+
     $.score = 0
     $.earn = false
     await getTaskDetail(-1)
@@ -86,10 +90,6 @@ async function main() {
     await helpFriends()
     await getTaskDetail(22);
     await getTaskDetail(-1)
-
-    if (reward) {
-      await getCommodities()
-    }
 
   } catch (e) {
     $.logErr(e)


### PR DESCRIPTION
健康社区兑换京豆任务放到最前面执行，因为每天凌晨跑完所有任务后，20豆都没货了，导致每天都无法兑换京豆。